### PR TITLE
[CHUNGCHUN-35] 유저 프로필 수정 API 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 
-src/main/resources/application.yml
+src/main/resources/*.yml

--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.youth_be.user.controller.spec.UserSpec;
 import org.example.youth_be.user.service.UserService;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
+import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.user.service.response.UserProfileDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -24,5 +25,11 @@ public class UserController implements UserSpec {
     @ResponseStatus(HttpStatus.OK)
     public UserProfileDto getUserProfile(@PathVariable Long userId) {
         return userService.getUserProfile(userId);
+    }
+
+    @PatchMapping("/{userId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void updateUserProfile(@PathVariable Long userId, @RequestBody UserProfileUpdateRequest request) {
+        userService.updateUserProfile(userId, request);
     }
 }

--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -27,7 +27,7 @@ public class UserController implements UserSpec {
         return userService.getUserProfile(userId);
     }
 
-    @PatchMapping("/{userId}")
+    @PutMapping("/{userId}")
     @ResponseStatus(HttpStatus.OK)
     public void updateUserProfile(@PathVariable Long userId, @RequestBody UserProfileUpdateRequest request) {
         userService.updateUserProfile(userId, request);

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.example.youth_be.common.ApiTags;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
+import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.user.service.response.UserProfileDto;
 
 @Tag(name = ApiTags.USER)
@@ -13,4 +14,7 @@ public interface UserSpec {
 
     @Operation(description = "유저 프로필 조회 API")
     UserProfileDto getUserProfile(Long userId);
+
+    @Operation(description = "유저 프로필 수정 API")
+    void updateUserProfile(Long userId, UserProfileUpdateRequest request);
 }

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -67,11 +67,4 @@ public class UserEntity {
         this.description = description;
         this.link = link;
     }
-
-    public void updateProfile(String nickname, String major, String description, String link) {
-        this.nickname = nickname;
-        this.major = major;
-        this.description = description;
-        this.link = link;
-    }
 }

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -29,12 +29,12 @@ public class UserEntity {
     @Column(length = 50, nullable = false)
     private String nickname;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 50)
     private String major;
 
     private String description;
 
-    @Column(nullable = false)
+    @Column(length = 1000)
     private String link;
 
     @Enumerated(EnumType.STRING)
@@ -58,5 +58,20 @@ public class UserEntity {
         this.userRole = userRole;
         this.totalLikeCount = totalLikeCount;
         this.followerCount = followerCount;
+    }
+
+    public void updateProfile(String profileImageUrl, String nickname, String major, String description, String link) {
+        this.profileImageUrl = profileImageUrl;
+        this.nickname = nickname;
+        this.major = major;
+        this.description = description;
+        this.link = link;
+    }
+
+    public void updateProfile(String nickname, String major, String description, String link) {
+        this.nickname = nickname;
+        this.major = major;
+        this.description = description;
+        this.link = link;
     }
 }

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -43,17 +43,6 @@ public class UserService {
     @Transactional
     public void updateUserProfile(Long userId, UserProfileUpdateRequest request){
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new IllegalStateException("해당 ID의 유저를 찾을 수 없습니다."));
-
-        String profileImageUrl = request.getProfileImageUrl().orElse(null);// 추후 기본 프로필 url로 설정
-        String major = request.getMajor().orElse(null);
-        String description = request.getDescription().orElse(null);
-        String link = request.getLink().orElse(null);
-
-        if (profileImageUrl != null) {
-            userEntity.updateProfile(profileImageUrl, request.getNickname(), major, description, link);
-            return;
-        }
-
-        userEntity.updateProfile(request.getNickname(), major, description, link);
+        userEntity.updateProfile(request.getProfileImageUrl(), request.getNickname(), request.getMajor(), request.getDescription(), request.getLink());
     }
 }

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.youth_be.user.domain.UserEntity;
 import org.example.youth_be.user.repository.UserRepository;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
+import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.user.service.response.UserProfileDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,5 +38,22 @@ public class UserService {
     public UserProfileDto getUserProfile(Long userId) {
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new IllegalStateException("해당 ID의 유저를 찾을 수 없습니다."));
         return UserProfileDto.of(userEntity);
+    }
+
+    @Transactional
+    public void updateUserProfile(Long userId, UserProfileUpdateRequest request){
+        UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new IllegalStateException("해당 ID의 유저를 찾을 수 없습니다."));
+
+        String profileImageUrl = request.getProfileImageUrl().orElse(null);// 추후 기본 프로필 url로 설정
+        String major = request.getMajor().orElse(null);
+        String description = request.getDescription().orElse(null);
+        String link = request.getLink().orElse(null);
+
+        if (profileImageUrl != null) {
+            userEntity.updateProfile(profileImageUrl, request.getNickname(), major, description, link);
+            return;
+        }
+
+        userEntity.updateProfile(request.getNickname(), major, description, link);
     }
 }

--- a/src/main/java/org/example/youth_be/user/service/request/UserProfileUpdateRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/UserProfileUpdateRequest.java
@@ -1,0 +1,16 @@
+package org.example.youth_be.user.service.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+@AllArgsConstructor
+public class UserProfileUpdateRequest {
+    private Optional<String> profileImageUrl;
+    private String nickname;
+    private Optional<String> major;
+    private Optional<String> description;
+    private Optional<String> link;
+}

--- a/src/main/java/org/example/youth_be/user/service/request/UserProfileUpdateRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/UserProfileUpdateRequest.java
@@ -8,9 +8,9 @@ import java.util.Optional;
 @Getter
 @AllArgsConstructor
 public class UserProfileUpdateRequest {
-    private Optional<String> profileImageUrl;
+    private String profileImageUrl;
     private String nickname;
-    private Optional<String> major;
-    private Optional<String> description;
-    private Optional<String> link;
+    private String major;
+    private String description;
+    private String link;
 }


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
feature (#35)
[35번 티켓](https://songminhyuk0308.atlassian.net/browse/CHUNGCHUN-35?atlOrigin=eyJpIjoiYzgxODFhMmE0ZmE5NGZiYjk4YWExYTg1ZmQxOWE3ZDMiLCJwIjoiaiJ9)
### 📌 작업사항
- 유저 프로필 수정 개발
- nullable 해제
- SWAGGER 추가
- null 값 요청에 대한 optional 처리

### 🔥 리뷰어가 참고할 사항
- 네이밍은 좌홍님과 유사하게 맞춰놨습니다.
- swagger 에도 추가했습니다.
- null 요청을 현재 아래와 같이 처리하고 있는데, 더 좋은 방식이 있으면 말씀해주세요!
``` java
public void updateUserProfile(Long userId, UserProfileUpdateRequest request){
        UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new IllegalStateException("해당 ID의 유저를 찾을 수 없습니다."));

        String profileImageUrl = request.getProfileImageUrl().orElse(null);// 추후 기본 프로필 url로 설정
        String major = request.getMajor().orElse(null);
        String description = request.getDescription().orElse(null);
        String link = request.getLink().orElse(null);

        if (profileImageUrl != null) {
            userEntity.updateProfile(profileImageUrl, request.getNickname(), major, description, link);
            return;
        }

        userEntity.updateProfile(request.getNickname(), major, description, link);
    }
```