### PR TITLE
[CHUNGCHUN-36] 작품 목록 조회 + 무한 스크롤 + 작품 mock 데이터 POST API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // QueryDSL Implementation
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
@@ -53,4 +60,21 @@ tasks.register('copySecret', Copy) {
     from './config'
     include "application*.yml"  // 복사할 파일들
     into 'src/main/resources'  // 복사 위치
+}
+
+/**
+ * QueryDSL Build Options
+ */
+def querydslDir = "src/main/generated"
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/org/example/youth_be/YouthBeApplication.java
+++ b/src/main/java/org/example/youth_be/YouthBeApplication.java
@@ -3,9 +3,11 @@ package org.example.youth_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableJpaAuditing
 public class YouthBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
+++ b/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
@@ -1,6 +1,7 @@
 package org.example.youth_be.artwork.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.youth_be.artwork.controller.spec.ArtworkSpec;
 import org.example.youth_be.artwork.service.ArtworkService;
 import org.example.youth_be.artwork.service.request.DevArtworkCreateRequest;
 import org.springframework.http.HttpStatus;
@@ -9,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/artworks")
-public class ArtworkController {
+public class ArtworkController implements ArtworkSpec {
 
     private final ArtworkService artworkService;
 

--- a/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
+++ b/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
@@ -1,0 +1,21 @@
+package org.example.youth_be.artwork.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.youth_be.artwork.service.ArtworkService;
+import org.example.youth_be.artwork.service.request.DevArtworkCreateRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/artworks")
+public class ArtworkController {
+
+    private final ArtworkService artworkService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createArtworkForDev(@RequestBody DevArtworkCreateRequest request) {
+        artworkService.createArtworkForDev(request);
+    }
+}

--- a/src/main/java/org/example/youth_be/artwork/controller/spec/ArtworkSpec.java
+++ b/src/main/java/org/example/youth_be/artwork/controller/spec/ArtworkSpec.java
@@ -1,0 +1,12 @@
+package org.example.youth_be.artwork.controller.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.youth_be.artwork.service.request.DevArtworkCreateRequest;
+import org.example.youth_be.common.ApiTags;
+
+@Tag(name = ApiTags.ARTWORK)
+public interface ArtworkSpec {
+    @Operation(description = "mock 데이터 용 작품 업로드 API입니다.")
+    void createArtworkForDev(DevArtworkCreateRequest request);
+}

--- a/src/main/java/org/example/youth_be/artwork/domain/ArtworkEntity.java
+++ b/src/main/java/org/example/youth_be/artwork/domain/ArtworkEntity.java
@@ -32,10 +32,12 @@ public class ArtworkEntity extends BaseEntity {
 
     private Long commentCount;
 
+    private String thumbnailImageUrl;
+
     private Long userId;
 
     @Builder
-    public ArtworkEntity(Long artworkId, String title, String description, ArtworkStatus artworkStatus, Long viewCount, Long likeCount, Long commentCount, Long userId) {
+    public ArtworkEntity(Long artworkId, String title, String description, ArtworkStatus artworkStatus, Long viewCount, Long likeCount, Long commentCount, String thumbnailImageUrl, Long userId) {
         this.artworkId = artworkId;
         this.title = title;
         this.description = description;
@@ -43,6 +45,7 @@ public class ArtworkEntity extends BaseEntity {
         this.viewCount = viewCount;
         this.likeCount = likeCount;
         this.commentCount = commentCount;
+        this.thumbnailImageUrl = thumbnailImageUrl;
         this.userId = userId;
     }
 

--- a/src/main/java/org/example/youth_be/artwork/domain/ArtworkEntity.java
+++ b/src/main/java/org/example/youth_be/artwork/domain/ArtworkEntity.java
@@ -6,12 +6,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.youth_be.artwork.enums.ArtworkStatus;
+import org.example.youth_be.common.entity.BaseEntity;
 
 @Entity
 @Table(name = "Artwork")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ArtworkEntity {
+public class ArtworkEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long artworkId;

--- a/src/main/java/org/example/youth_be/artwork/repository/ArtworkRepository.java
+++ b/src/main/java/org/example/youth_be/artwork/repository/ArtworkRepository.java
@@ -7,9 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ArtworkRepository extends JpaRepository<ArtworkEntity, Long> {
+public interface ArtworkRepository extends JpaRepository<ArtworkEntity, Long>, ArtworkRepositoryCustom {
 
-    Slice<ArtworkEntity> findAllByUserIdOrderByArtworkIdDesc(Long userId, Pageable pageable);
-
-    Slice<ArtworkEntity> findByUserIdAndArtworkIdLessThanOrderByArtworkIdDesc(Long userId, Long artworkId, Pageable page);
 }

--- a/src/main/java/org/example/youth_be/artwork/repository/ArtworkRepository.java
+++ b/src/main/java/org/example/youth_be/artwork/repository/ArtworkRepository.java
@@ -1,9 +1,15 @@
 package org.example.youth_be.artwork.repository;
 
 import org.example.youth_be.artwork.domain.ArtworkEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ArtworkRepository extends JpaRepository<ArtworkEntity, Long> {
+
+    Slice<ArtworkEntity> findAllByUserIdOrderByArtworkIdDesc(Long userId, Pageable pageable);
+
+    Slice<ArtworkEntity> findByUserIdAndArtworkIdLessThanOrderByArtworkIdDesc(Long userId, Long artworkId, Pageable page);
 }

--- a/src/main/java/org/example/youth_be/artwork/repository/ArtworkRepositoryCustom.java
+++ b/src/main/java/org/example/youth_be/artwork/repository/ArtworkRepositoryCustom.java
@@ -1,0 +1,16 @@
+package org.example.youth_be.artwork.repository;
+
+import org.example.youth_be.user.service.response.UserArtworkResponse;
+import org.springframework.data.domain.Slice;
+
+public interface ArtworkRepositoryCustom {
+    // 유저 마이페이지에서 전체 작품 조회
+    Slice<UserArtworkResponse> findAllByCondition(Long userId, Long cursorId, Integer size);
+
+    // 유저 마이페이지에서 판매중 작품 조회
+    Slice<UserArtworkResponse> findSellingsByCondition(Long userId, Long cursorId, Integer size);
+
+    // 유저 마이페이지에서 유저가 좋아요한 작품 조회
+    Slice<UserArtworkResponse> findLikedByCondition(Long userId, Long cursorId, Integer size);
+
+}

--- a/src/main/java/org/example/youth_be/artwork/repository/ArtworkRepositoryImpl.java
+++ b/src/main/java/org/example/youth_be/artwork/repository/ArtworkRepositoryImpl.java
@@ -1,0 +1,137 @@
+package org.example.youth_be.artwork.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.youth_be.artwork.domain.ArtworkEntity;
+import org.example.youth_be.artwork.domain.QArtworkEntity;
+import org.example.youth_be.artwork.enums.ArtworkStatus;
+import org.example.youth_be.like.domain.QLikeEntity;
+import org.example.youth_be.user.domain.QUserEntity;
+import org.example.youth_be.user.domain.UserEntity;
+import org.example.youth_be.user.service.response.UserArtworkResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class ArtworkRepositoryImpl implements ArtworkRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QArtworkEntity artwork = QArtworkEntity.artworkEntity;
+    QUserEntity user = QUserEntity.userEntity;
+    QLikeEntity like = QLikeEntity.likeEntity;
+
+    @Override
+    public Slice<UserArtworkResponse> findAllByCondition(Long userId, Long cursorId, Integer size) {
+
+        UserEntity artist = jpaQueryFactory
+                .selectFrom(user)
+                .where(user.userId.eq(userId))
+                .fetchOne();
+
+        // 사용자 ID와 커서 ID를 기준으로 Artwork 조회
+        List<ArtworkEntity> artworks = jpaQueryFactory
+                .selectFrom(artwork)
+                .where(artwork.userId.eq(userId)
+                        .and(artwork.artworkId.lt(cursorId))) // 사용자 ID와 커서 ID로 필터링
+                .orderBy(artwork.artworkId.desc())
+                .limit(size + 1) // hasNext 판단을 위해 size + 1개 조회
+                .fetch();
+
+        // UserArtworkResponse로 변환 (작가 정보 조회 생략)
+        List<UserArtworkResponse> responses = artworks.stream().limit(size).map(a ->
+                UserArtworkResponse.of(a.getArtworkId(), a.getTitle(), a.getDescription(), a.getArtworkStatus(),
+                        a.getViewCount(), a.getLikeCount(), a.getCommentCount(), a.getThumbnailImageUrl(), userId,
+                        artist.getNickname(), artist.getProfileImageUrl(), a.getCreatedAt(), a.getUpdatedAt())).collect(Collectors.toList());
+
+        boolean hasNext = artworks.size() > size;
+
+        // Pageable 객체 생성
+        Pageable pageable = PageRequest.of(0, size);
+
+        // SliceImpl 객체로 반환
+        return new SliceImpl<>(responses, pageable, hasNext);
+    }
+
+    @Override
+    public Slice<UserArtworkResponse> findSellingsByCondition(Long userId, Long cursorId, Integer size) {
+        UserEntity artist = jpaQueryFactory
+                .selectFrom(user)
+                .where(user.userId.eq(userId))
+                .fetchOne();
+
+        // 사용자 ID와 커서 ID를 기준으로 Artwork 조회, 단, ArtworkStatus가 SELLING인 경우만
+        List<ArtworkEntity> artworks = jpaQueryFactory
+                .selectFrom(artwork)
+                .where(artwork.userId.eq(userId)
+                        .and(artwork.artworkId.lt(cursorId)) // 커서 ID 조건
+                        .and(artwork.artworkStatus.eq(ArtworkStatus.SELLING))) // ArtworkStatus가 SELLING인 경우만 필터링
+                .orderBy(artwork.artworkId.desc())
+                .limit(size + 1) // 다음 페이지 존재 여부 확인을 위해 size + 1개 조회
+                .fetch();
+
+        // UserArtworkResponse로 변환
+        List<UserArtworkResponse> responses = artworks.stream().limit(size).map(a ->
+                UserArtworkResponse.of(a.getArtworkId(), a.getTitle(), a.getDescription(), a.getArtworkStatus(),
+                        a.getViewCount(), a.getLikeCount(), a.getCommentCount(), a.getThumbnailImageUrl(), userId,
+                        artist.getNickname(), artist.getProfileImageUrl(), a.getCreatedAt(), a.getUpdatedAt())
+        ).collect(Collectors.toList());
+
+        boolean hasNext = artworks.size() > size; // 조회된 목록의 크기가 요청된 size보다 크면 다음 페이지가 존재
+
+        // Pageable 객체 생성
+        Pageable pageable = PageRequest.of(0, size);
+
+        // SliceImpl 객체로 반환
+        return new SliceImpl<>(responses, pageable, hasNext);
+    }
+
+
+    @Override
+    public Slice<UserArtworkResponse> findLikedByCondition(Long userId, Long cursorId, Integer size) {
+
+        // Step 1: 사용자가 좋아요한 Artwork의 ID 목록 조회
+        List<Long> likedArtworkIds = jpaQueryFactory
+                .select(like.artworkId)
+                .from(like)
+                .where(like.userId.eq(userId))
+                .fetch();
+
+        // Step 2: 좋아요한 Artwork 조회
+        List<ArtworkEntity> artworks = jpaQueryFactory
+                .selectFrom(artwork)
+                .where(artwork.artworkId.in(likedArtworkIds)
+                        .and(artwork.artworkId.lt(cursorId)))
+                .orderBy(artwork.artworkId.desc())
+                .limit(size + 1) // hasNext 판단을 위해 size + 1개 조회
+                .fetch();
+
+        // UserArtworkResponse로 변환
+        List<UserArtworkResponse> responses = artworks.stream().limit(size).map(a -> {
+            // UserEntity 조회
+            UserEntity artist = jpaQueryFactory
+                    .selectFrom(user)
+                    .where(user.userId.eq(a.getUserId()))
+                    .fetchOne();
+
+            return UserArtworkResponse.of(a.getArtworkId(), a.getTitle(), a.getDescription(), a.getArtworkStatus(),
+                    a.getViewCount(), a.getLikeCount(), a.getCommentCount(), a.getThumbnailImageUrl(), a.getUserId(),
+                    artist.getNickname(), artist.getProfileImageUrl(), a.getCreatedAt(), a.getUpdatedAt());
+        }).collect(Collectors.toList());
+
+
+        boolean hasNext = artworks.size() > size;
+
+        // Pageable 객체 생성
+        Pageable pageable = PageRequest.of(0, size);
+
+        // SliceImpl 객체로 반환
+        return new SliceImpl<>(responses, pageable, hasNext);
+    }
+}

--- a/src/main/java/org/example/youth_be/artwork/service/ArtworkService.java
+++ b/src/main/java/org/example/youth_be/artwork/service/ArtworkService.java
@@ -1,0 +1,24 @@
+package org.example.youth_be.artwork.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.youth_be.artwork.domain.ArtworkEntity;
+import org.example.youth_be.artwork.repository.ArtworkRepository;
+import org.example.youth_be.artwork.service.request.DevArtworkCreateRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ArtworkService {
+
+    private final ArtworkRepository artworkRepository;
+
+    /**
+     * 개발용입니다.
+     */
+    @Transactional
+    public void createArtworkForDev(DevArtworkCreateRequest request) {
+        ArtworkEntity entity = request.toEntity();
+        artworkRepository.save(entity);
+    }
+}

--- a/src/main/java/org/example/youth_be/artwork/service/request/ArtworkPaginationRequest.java
+++ b/src/main/java/org/example/youth_be/artwork/service/request/ArtworkPaginationRequest.java
@@ -1,0 +1,10 @@
+package org.example.youth_be.artwork.service.request;
+
+import lombok.Getter;
+
+@Getter
+public class ArtworkPaginationRequest {
+
+    private Integer size;
+    private Long lastIdxId;
+}

--- a/src/main/java/org/example/youth_be/artwork/service/request/DevArtworkCreateRequest.java
+++ b/src/main/java/org/example/youth_be/artwork/service/request/DevArtworkCreateRequest.java
@@ -1,0 +1,32 @@
+package org.example.youth_be.artwork.service.request;
+
+import lombok.Getter;
+import org.example.youth_be.artwork.domain.ArtworkEntity;
+import org.example.youth_be.artwork.enums.ArtworkStatus;
+
+import java.util.UUID;
+import java.util.random.RandomGenerator;
+
+@Getter
+public class DevArtworkCreateRequest {
+
+    private final String title = UUID.randomUUID().toString() + "작품 제목";
+    private final String description = UUID.randomUUID().toString() + "작품 설명";
+    private final ArtworkStatus artworkStatus = ArtworkStatus.PUBLIC;
+    private final Long viewCount = Math.abs(RandomGenerator.getDefault().nextLong() % 100);
+    private final Long likeCount = Math.abs(RandomGenerator.getDefault().nextLong() % 100);
+    private final Long commentCount = Math.abs(RandomGenerator.getDefault().nextLong() % 100);
+    private final Long userId = 1L;
+
+    public ArtworkEntity toEntity(){
+        return ArtworkEntity.builder()
+                .title(this.title)
+                .description(this.description)
+                .artworkStatus(this.artworkStatus)
+                .viewCount(this.viewCount)
+                .likeCount(this.likeCount)
+                .commentCount(this.commentCount)
+                .userId(this.userId)
+                .build();
+    }
+}

--- a/src/main/java/org/example/youth_be/comment/domain/CommentEntity.java
+++ b/src/main/java/org/example/youth_be/comment/domain/CommentEntity.java
@@ -5,12 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.youth_be.common.entity.BaseEntity;
 
 @Entity
 @Table(name = "comment")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CommentEntity {
+public class CommentEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/example/youth_be/common/ApiTags.java
+++ b/src/main/java/org/example/youth_be/common/ApiTags.java
@@ -3,4 +3,6 @@ package org.example.youth_be.common;
 public class ApiTags {
     public static final String USER = "유저 API";
     public static final String IMAGE = "이미지 업로드 API";
+
+    public static final String ARTWORK = "작품 API";
 }

--- a/src/main/java/org/example/youth_be/common/PageResponse.java
+++ b/src/main/java/org/example/youth_be/common/PageResponse.java
@@ -11,9 +11,8 @@ import java.util.List;
 public class PageResponse<T> {
     private List<T> contents;
     private boolean hasNext;
-    private Long cursorId;
 
-    public static <T> PageResponse<T> of(Slice<T> slice, Long cursorId) {
-        return new PageResponse<>(slice.getContent(), slice.hasNext(), cursorId);
+    public static <T> PageResponse<T> of(Slice<T> slice) {
+        return new PageResponse<>(slice.getContent(), slice.hasNext());
     }
 }

--- a/src/main/java/org/example/youth_be/common/PageResponse.java
+++ b/src/main/java/org/example/youth_be/common/PageResponse.java
@@ -11,8 +11,9 @@ import java.util.List;
 public class PageResponse<T> {
     private List<T> contents;
     private boolean hasNext;
+    private Long cursorId;
 
-    public static <T> PageResponse<T> of(Slice<T> slice) {
-        return new PageResponse<>(slice.getContent(), slice.hasNext());
+    public static <T> PageResponse<T> of(Slice<T> slice, Long cursorId) {
+        return new PageResponse<>(slice.getContent(), slice.hasNext(), cursorId);
     }
 }

--- a/src/main/java/org/example/youth_be/common/QueryDslConfig.java
+++ b/src/main/java/org/example/youth_be/common/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package org.example.youth_be.common;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/org/example/youth_be/common/entity/BaseEntity.java
+++ b/src/main/java/org/example/youth_be/common/entity/BaseEntity.java
@@ -1,0 +1,30 @@
+package org.example.youth_be.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false, columnDefinition = "TIMESTAMP")
+    @Comment("생성일자")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(columnDefinition = "TIMESTAMP")
+    @Comment("수정일자")
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/org/example/youth_be/follow/domain/FollowEntity.java
+++ b/src/main/java/org/example/youth_be/follow/domain/FollowEntity.java
@@ -5,12 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.youth_be.common.entity.BaseEntity;
 
 @Entity
 @Table(name = "follow")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FollowEntity {
+public class FollowEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/example/youth_be/image/domain/ImageEntity.java
+++ b/src/main/java/org/example/youth_be/image/domain/ImageEntity.java
@@ -5,12 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.youth_be.common.entity.BaseEntity;
 
 @Entity
 @Table(name = "image")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ImageEntity {
+public class ImageEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/example/youth_be/like/domain/LikeEntity.java
+++ b/src/main/java/org/example/youth_be/like/domain/LikeEntity.java
@@ -5,12 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.youth_be.common.entity.BaseEntity;
 
 @Entity
 @Table(name = "likes")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LikeEntity {
+public class LikeEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long likeId;

--- a/src/main/java/org/example/youth_be/link/domain/LinkEntity.java
+++ b/src/main/java/org/example/youth_be/link/domain/LinkEntity.java
@@ -5,12 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.youth_be.common.entity.BaseEntity;
 
 @Entity
 @Table(name = "link")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LinkEntity {
+public class LinkEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long linkId;

--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package org.example.youth_be.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.youth_be.artwork.domain.ArtworkEntity;
+import org.example.youth_be.common.PageResponse;
 import org.example.youth_be.user.controller.spec.UserSpec;
 import org.example.youth_be.user.service.UserService;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
@@ -31,5 +33,11 @@ public class UserController implements UserSpec {
     @ResponseStatus(HttpStatus.OK)
     public void updateUserProfile(@PathVariable Long userId, @RequestBody UserProfileUpdateRequest request) {
         userService.updateUserProfile(userId, request);
+    }
+
+    @GetMapping("/{userId}/artworks")
+    @ResponseStatus(HttpStatus.OK)
+    public PageResponse<ArtworkEntity> getUserArtworks(@PathVariable Long userId, @RequestParam(required = false) Long artworkId) {
+        return userService.getUserArtworks(userId, artworkId);
     }
 }

--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -1,11 +1,15 @@
 package org.example.youth_be.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
+import org.example.youth_be.common.PageResponse;
 import org.example.youth_be.user.controller.spec.UserSpec;
+import org.example.youth_be.user.enums.ArtworkType;
 import org.example.youth_be.user.service.UserService;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
 import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
+import org.example.youth_be.user.service.response.UserArtworkResponse;
 import org.example.youth_be.user.service.response.UserProfileResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -44,5 +48,11 @@ public class UserController implements UserSpec {
     @ResponseStatus(HttpStatus.OK)
     public void deleteUserLink(@PathVariable Long userId, @PathVariable Long linkId) {
         userService.deleteUserLink(userId, linkId);
+    }
+
+    @GetMapping("/{userId}/artworks")
+    @ResponseStatus(HttpStatus.OK)
+    public PageResponse<UserArtworkResponse> getUserArtworks(@PathVariable Long userId, @RequestParam ArtworkType type, @ModelAttribute ArtworkPaginationRequest request) {
+        return userService.getUserArtworks(userId, type, request);
     }
 }

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
@@ -2,10 +2,14 @@ package org.example.youth_be.user.controller.spec;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
 import org.example.youth_be.common.ApiTags;
+import org.example.youth_be.common.PageResponse;
+import org.example.youth_be.user.enums.ArtworkType;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
 import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
+import org.example.youth_be.user.service.response.UserArtworkResponse;
 import org.example.youth_be.user.service.response.UserProfileResponse;
 
 @Tag(name = ApiTags.USER)
@@ -24,4 +28,8 @@ public interface UserSpec {
 
     @Operation(description = "유저 링크 삭제 API")
     void deleteUserLink(Long userId, Long linkId);
+
+    @Operation(description = "유저의 작품 조회 API")
+    PageResponse<UserArtworkResponse> getUserArtworks(Long userId, ArtworkType type, ArtworkPaginationRequest request);
+
 }

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
@@ -2,7 +2,9 @@ package org.example.youth_be.user.controller.spec;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.youth_be.artwork.domain.ArtworkEntity;
 import org.example.youth_be.common.ApiTags;
+import org.example.youth_be.common.PageResponse;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.user.service.response.UserProfileDto;
@@ -17,4 +19,7 @@ public interface UserSpec {
 
     @Operation(description = "유저 프로필 수정 API")
     void updateUserProfile(Long userId, UserProfileUpdateRequest request);
+
+    @Operation(description = "유저의 작품 조회 API")
+    PageResponse<ArtworkEntity> getUserArtworks(Long userId, Long artworkId);
 }

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.youth_be.common.entity.BaseEntity;
 import org.example.youth_be.user.enums.SocialTypeEnum;
 import org.example.youth_be.user.enums.UserRoleEnum;
 
@@ -12,7 +13,7 @@ import org.example.youth_be.user.enums.UserRoleEnum;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserEntity {
+public class UserEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;

--- a/src/main/java/org/example/youth_be/user/enums/ArtworkType.java
+++ b/src/main/java/org/example/youth_be/user/enums/ArtworkType.java
@@ -1,0 +1,14 @@
+package org.example.youth_be.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ArtworkType {
+
+    ALL("전체"),SELLING("판매중"),COLLECTION("컬렉션");
+
+    private final String description;
+
+}

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -1,6 +1,8 @@
 package org.example.youth_be.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.youth_be.artwork.domain.ArtworkEntity;
+import org.example.youth_be.artwork.repository.ArtworkRepository;
 import org.example.youth_be.common.PageResponse;
 import org.example.youth_be.common.exceptions.YouthNotFoundException;
 import org.example.youth_be.user.domain.UserEntity;
@@ -8,16 +10,20 @@ import org.example.youth_be.user.repository.UserRepository;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.user.service.response.UserProfileDto;
-import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    final int COUNT_PER_SCROLL = 15;
+
     private final UserRepository userRepository;
+    private final ArtworkRepository artworkRepository;
 
     /**
      * 개발용입니다.
@@ -46,8 +52,33 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUserProfile(Long userId, UserProfileUpdateRequest request){
+    public void updateUserProfile(Long userId, UserProfileUpdateRequest request) {
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new YouthNotFoundException("해당 ID의 유저를 찾을 수 없습니다.", null));
         userEntity.updateProfile(request.getProfileImageUrl(), request.getNickname(), request.getMajor(), request.getDescription(), request.getLink());
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ArtworkEntity> getUserArtworks(Long userId, Long artworkId) {
+        PageRequest pageable = PageRequest.of(0, COUNT_PER_SCROLL);
+        Slice<ArtworkEntity> artworks = getArtwork(userId, artworkId, pageable);
+
+        Long lastArtworkId = null;
+        if (!artworks.isEmpty()) {
+            List<ArtworkEntity> content = artworks.getContent();
+            lastArtworkId = content.get(content.size() - 1).getArtworkId(); // 마지막 artwork의 ID
+        }
+
+        return PageResponse.of(artworks, lastArtworkId);
+    }
+
+    private Slice<ArtworkEntity> getArtwork(Long userId, Long artworkId, Pageable page) {
+
+        if (artworkId == null) {
+            // 첫 번째 페이지 요청 시 가장 최신의 데이터부터 시작
+            return this.artworkRepository.findAllByUserIdOrderByArtworkIdDesc(userId, page);
+        } else {
+            // 커서 기반 페이징: 주어진 artworkId보다 작은 데이터 조회
+            return this.artworkRepository.findByUserIdAndArtworkIdLessThanOrderByArtworkIdDesc(userId, artworkId, page);
+        }
     }
 }

--- a/src/main/java/org/example/youth_be/user/service/response/UserArtworkResponse.java
+++ b/src/main/java/org/example/youth_be/user/service/response/UserArtworkResponse.java
@@ -1,0 +1,43 @@
+package org.example.youth_be.user.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.youth_be.artwork.enums.ArtworkStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserArtworkResponse {
+    private Long artworkId;
+    private String title;
+    private String description;
+    private ArtworkStatus artworkStatus;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    private String thumbnailImageUrl;
+    private Long artistId;
+    private String artistName;
+    private String artistProfileImageUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static UserArtworkResponse of(Long artworkId, String title, String description, ArtworkStatus artworkStatus, Long viewCount, Long likeCount, Long commentCount, String thumbnailImageUrl, Long artistId, String artistName, String artistProfileImageUrl, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return UserArtworkResponse.builder()
+                .artworkId(artworkId)
+                .title(title)
+                .description(description)
+                .artworkStatus(artworkStatus)
+                .viewCount(viewCount)
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .artistId(artistId)
+                .artistName(artistName)
+                .artistProfileImageUrl(artistProfileImageUrl)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,4 @@
-spring.config.activate.on-profile: test
+spring.config.activate.on-profile: local
 
 spring:
   config:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,6 +1,9 @@
 spring.config.activate.on-profile: test
 
 spring:
+  config:
+    import:
+        - application-secret-aws.yml
 
   # H2 Setting Info (H2 Console에 접속하기 위한 설정정보 입력)
   h2:


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
feature (#36)
[티켓](https://songminhyuk0308.atlassian.net/browse/CHUNGCHUN-36?atlOrigin=eyJpIjoiMTAxOWRhNzE3YjlkNGFhMmI5MDRkZmI2MGRmYjIyOGMiLCJwIjoiaiJ9)

### 📌 작업사항
- 유저 작품을 커서 기반 페이징 조회
- BaseEntity 추가 및 적용
- 유저 작품 생성을 위한 mock api 생성

### 🔥 리뷰어가 참고할 사항
- 커서기반으로 조회하는 로직 구현했습니다. 처음 짜보는 거라 부족한 부분있으면 말씀해주세요!
- 그리고 혹시 delete에 대해서는 soft delete 적용은 어떨까요??
- PageRepsone에 마지막 커서 아이디 추가했습니다!