### PR TITLE
[FIX] 유저의 링크 생성 & 삭제 api 추가 + 유저 프로필 조회 프로퍼티 변경

### DIFF
--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.youth_be.user.controller.spec.UserSpec;
 import org.example.youth_be.user.service.UserService;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
+import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.user.service.response.UserProfileResponse;
 import org.springframework.http.HttpStatus;
@@ -31,5 +32,17 @@ public class UserController implements UserSpec {
     @ResponseStatus(HttpStatus.OK)
     public void updateUserProfile(@PathVariable Long userId, @RequestBody UserProfileUpdateRequest request) {
         userService.updateUserProfile(userId, request);
+    }
+
+    @PostMapping("/{userId}/links")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Long createUserLink(@PathVariable Long userId, @RequestBody LinkRequest request) {
+        return userService.createUserLink(userId, request);
+    }
+
+    @DeleteMapping("/{userId}/links/{linkId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteUserLink(@PathVariable Long userId, @PathVariable Long linkId) {
+        userService.deleteUserLink(userId, linkId);
     }
 }

--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -5,7 +5,7 @@ import org.example.youth_be.user.controller.spec.UserSpec;
 import org.example.youth_be.user.service.UserService;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
-import org.example.youth_be.user.service.response.UserProfileDto;
+import org.example.youth_be.user.service.response.UserProfileResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,13 +17,13 @@ public class UserController implements UserSpec {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void createUserForDev(@RequestBody DevUserProfileCreateRequest request) {
-        userService.createUserForDev(request);
+    public Long createUserForDev(@RequestBody DevUserProfileCreateRequest request) {
+        return userService.createUserForDev(request);
     }
 
     @GetMapping("/{userId}")
     @ResponseStatus(HttpStatus.OK)
-    public UserProfileDto getUserProfile(@PathVariable Long userId) {
+    public UserProfileResponse getUserProfile(@PathVariable Long userId) {
         return userService.getUserProfile(userId);
     }
 

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
@@ -5,15 +5,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.example.youth_be.common.ApiTags;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
-import org.example.youth_be.user.service.response.UserProfileDto;
+import org.example.youth_be.user.service.response.UserProfileResponse;
 
 @Tag(name = ApiTags.USER)
 public interface UserSpec {
     @Operation(description = "개발용 유저 생성 API [값을 넣지 않으면 서버에서 임의로 넣습니다.]")
-    void createUserForDev(DevUserProfileCreateRequest request);
+    Long createUserForDev(DevUserProfileCreateRequest request);
 
     @Operation(description = "유저 프로필 조회 API")
-    UserProfileDto getUserProfile(Long userId);
+    UserProfileResponse getUserProfile(Long userId);
 
     @Operation(description = "유저 프로필 수정 API")
     void updateUserProfile(Long userId, UserProfileUpdateRequest request);

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.example.youth_be.common.ApiTags;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
+import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.user.service.response.UserProfileResponse;
 
@@ -17,4 +18,10 @@ public interface UserSpec {
 
     @Operation(description = "유저 프로필 수정 API")
     void updateUserProfile(Long userId, UserProfileUpdateRequest request);
+
+    @Operation(description = "유저 링크 생성 API")
+    Long createUserLink(Long userId, LinkRequest request);
+
+    @Operation(description = "유저 링크 삭제 API")
+    void deleteUserLink(Long userId, Long linkId);
 }

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -34,19 +34,12 @@ public class UserEntity {
 
     private String description;
 
-    @Column(length = 1000)
-    private String link;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private UserRoleEnum userRole;
-
     private Long totalLikeCount;
 
     private Long followerCount;
 
     @Builder
-    public UserEntity(Long userId, SocialTypeEnum socialType, String profileImageUrl, String socialId, String nickname, String major, String description, String link, UserRoleEnum userRole, Long totalLikeCount, Long followerCount) {
+    public UserEntity(Long userId, SocialTypeEnum socialType, String profileImageUrl, String socialId, String nickname, String major, String description, Long totalLikeCount, Long followerCount) {
         this.userId = userId;
         this.socialType = socialType;
         this.profileImageUrl = profileImageUrl;
@@ -54,17 +47,14 @@ public class UserEntity {
         this.nickname = nickname;
         this.major = major;
         this.description = description;
-        this.link = link;
-        this.userRole = userRole;
         this.totalLikeCount = totalLikeCount;
         this.followerCount = followerCount;
     }
 
-    public void updateProfile(String profileImageUrl, String nickname, String major, String description, String link) {
+    public void updateProfile(String profileImageUrl, String nickname, String major, String description) {
         this.profileImageUrl = profileImageUrl;
         this.nickname = nickname;
         this.major = major;
         this.description = description;
-        this.link = link;
     }
 }

--- a/src/main/java/org/example/youth_be/user/domain/UserLinkEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserLinkEntity.java
@@ -1,0 +1,32 @@
+package org.example.youth_be.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_link")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserLinkEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    @Column(length = 1000, nullable = false)
+    private String title;
+
+    @Column(length = 1000, nullable = false)
+    private String linkUrl;
+
+    @Builder
+    public UserLinkEntity(Long userId, String title, String linkUrl) {
+        this.userId = userId;
+        this.title = title;
+        this.linkUrl = linkUrl;
+    }
+}

--- a/src/main/java/org/example/youth_be/user/repository/UserLinkRepository.java
+++ b/src/main/java/org/example/youth_be/user/repository/UserLinkRepository.java
@@ -1,0 +1,12 @@
+package org.example.youth_be.user.repository;
+
+import org.example.youth_be.user.domain.UserLinkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserLinkRepository extends JpaRepository<UserLinkEntity, Long> {
+    List<UserLinkEntity> findAllByUserId(Long userId);
+}

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -1,53 +1,60 @@
 package org.example.youth_be.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.youth_be.common.PageResponse;
 import org.example.youth_be.common.exceptions.YouthNotFoundException;
 import org.example.youth_be.user.domain.UserEntity;
+import org.example.youth_be.user.domain.UserLinkEntity;
+import org.example.youth_be.user.repository.UserLinkRepository;
 import org.example.youth_be.user.repository.UserRepository;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
-import org.example.youth_be.user.service.response.UserProfileDto;
-import org.springframework.data.domain.SliceImpl;
+import org.example.youth_be.user.service.response.UserProfileResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final UserLinkRepository userLinkRepository;
 
     /**
      * 개발용입니다.
      */
     @Transactional
-    public void createUserForDev(DevUserProfileCreateRequest request) {
+    public Long createUserForDev(DevUserProfileCreateRequest request) {
         UserEntity userEntity = UserEntity.builder()
                 .profileImageUrl(request.getProfileImageUrl())
                 .major(request.getMajor())
-                .userRole(request.getUserRole())
                 .description(request.getDescription())
-                .link(request.getLink())
                 .followerCount(request.getFollowerCount())
                 .socialId(request.getSocialId())
                 .socialType(request.getSocialType())
                 .totalLikeCount(request.getTotalLikeCount())
                 .nickname(request.getNickname())
                 .build();
+        List<UserLinkEntity> userLinkEntities = request.getLinkRequestList().stream().map(linkRequest ->
+                UserLinkEntity.builder()
+                        .userId(userEntity.getUserId())
+                        .title(linkRequest.getTitle())
+                        .linkUrl(linkRequest.getUrl()).build()).toList();
+        userLinkRepository.saveAll(userLinkEntities);
         userRepository.save(userEntity);
+        return userEntity.getUserId();
     }
 
     @Transactional(readOnly = true)
-    public UserProfileDto getUserProfile(Long userId) {
+    public UserProfileResponse getUserProfile(Long userId) {
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new YouthNotFoundException("해당 ID의 유저를 찾을 수 없습니다.", null));
-        return UserProfileDto.of(userEntity);
+        List<UserLinkEntity> userLinkEntities = userLinkRepository.findAllByUserId(userId);
+        return UserProfileResponse.of(userEntity, userLinkEntities);
     }
 
     @Transactional
-    public void updateUserProfile(Long userId, UserProfileUpdateRequest request){
+    public void updateUserProfile(Long userId, UserProfileUpdateRequest request) {
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new YouthNotFoundException("해당 ID의 유저를 찾을 수 없습니다.", null));
-        userEntity.updateProfile(request.getProfileImageUrl(), request.getNickname(), request.getMajor(), request.getDescription(), request.getLink());
+        userEntity.updateProfile(request.getProfileImageUrl(), request.getNickname(), request.getMajor(), request.getDescription());
     }
 }

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -7,6 +7,7 @@ import org.example.youth_be.user.domain.UserLinkEntity;
 import org.example.youth_be.user.repository.UserLinkRepository;
 import org.example.youth_be.user.repository.UserRepository;
 import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
+import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.user.service.response.UserProfileResponse;
 import org.springframework.stereotype.Service;
@@ -57,5 +58,23 @@ public class UserService {
     public void updateUserProfile(Long userId, UserProfileUpdateRequest request) {
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new YouthNotFoundException("해당 ID의 유저를 찾을 수 없습니다.", null));
         userEntity.updateProfile(request.getProfileImageUrl(), request.getNickname(), request.getMajor(), request.getDescription());
+    }
+
+    @Transactional
+    public Long createUserLink(Long userId, LinkRequest request) {
+        userRepository.findById(userId).orElseThrow(() -> new YouthNotFoundException("해당 ID의 유저를 찾을 수 없습니다.", null));
+        UserLinkEntity newUserLinkEntity = UserLinkEntity.builder()
+                .userId(userId)
+                .title(request.getTitle())
+                .linkUrl(request.getUrl())
+                .build();
+        userLinkRepository.save(newUserLinkEntity);
+        return newUserLinkEntity.getUserId();
+    }
+
+    @Transactional
+    public void deleteUserLink(Long userId, Long linkId) {
+        userRepository.findById(userId).orElseThrow(() -> new YouthNotFoundException("해당 ID의 유저를 찾을 수 없습니다.", null));
+        userLinkRepository.deleteById(linkId);
     }
 }

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -35,13 +35,14 @@ public class UserService {
                 .totalLikeCount(request.getTotalLikeCount())
                 .nickname(request.getNickname())
                 .build();
+        userRepository.save(userEntity);
+
         List<UserLinkEntity> userLinkEntities = request.getLinkRequestList().stream().map(linkRequest ->
                 UserLinkEntity.builder()
                         .userId(userEntity.getUserId())
                         .title(linkRequest.getTitle())
                         .linkUrl(linkRequest.getUrl()).build()).toList();
         userLinkRepository.saveAll(userLinkEntities);
-        userRepository.save(userEntity);
         return userEntity.getUserId();
     }
 

--- a/src/main/java/org/example/youth_be/user/service/request/DevUserProfileCreateRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/DevUserProfileCreateRequest.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import org.example.youth_be.user.enums.SocialTypeEnum;
 import org.example.youth_be.user.enums.UserRoleEnum;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.random.RandomGenerator;
 
@@ -16,7 +18,7 @@ public class DevUserProfileCreateRequest {
     private String nickname = UUID.randomUUID().toString();
     private String major = "아무런학과";
     private String description = "아무런설명";
-    private String link = "아무런링크";
+    private List<LinkRequest> linkRequestList = new ArrayList<>();
     private Long totalLikeCount = Math.abs(RandomGenerator.getDefault().nextLong() % 100);
     private Long followerCount = Math.abs(RandomGenerator.getDefault().nextLong() % 100);
 }

--- a/src/main/java/org/example/youth_be/user/service/request/LinkRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/LinkRequest.java
@@ -1,0 +1,11 @@
+package org.example.youth_be.user.service.request;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LinkRequest {
+    private Long id;
+    private String title;
+    private String url;
+}

--- a/src/main/java/org/example/youth_be/user/service/request/LinkRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/LinkRequest.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class LinkRequest {
-    private Long id;
     private String title;
     private String url;
 }

--- a/src/main/java/org/example/youth_be/user/service/request/UserProfileUpdateRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/UserProfileUpdateRequest.java
@@ -3,6 +3,7 @@ package org.example.youth_be.user.service.request;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.Optional;
 
 @Getter
@@ -12,5 +13,4 @@ public class UserProfileUpdateRequest {
     private String nickname;
     private String major;
     private String description;
-    private String link;
 }

--- a/src/main/java/org/example/youth_be/user/service/response/LinkResponse.java
+++ b/src/main/java/org/example/youth_be/user/service/response/LinkResponse.java
@@ -1,0 +1,18 @@
+package org.example.youth_be.user.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.youth_be.user.domain.UserLinkEntity;
+
+@Getter
+@AllArgsConstructor
+public class LinkResponse {
+    private String title;
+    private String address;
+
+    static public LinkResponse of(UserLinkEntity userLinkEntity) {
+        return new LinkResponse(
+                userLinkEntity.getTitle(),
+                userLinkEntity.getLinkUrl());
+    }
+}

--- a/src/main/java/org/example/youth_be/user/service/response/LinkResponse.java
+++ b/src/main/java/org/example/youth_be/user/service/response/LinkResponse.java
@@ -7,11 +7,13 @@ import org.example.youth_be.user.domain.UserLinkEntity;
 @Getter
 @AllArgsConstructor
 public class LinkResponse {
+    private Long linkId;
     private String title;
     private String address;
 
     static public LinkResponse of(UserLinkEntity userLinkEntity) {
         return new LinkResponse(
+                userLinkEntity.getId(),
                 userLinkEntity.getTitle(),
                 userLinkEntity.getLinkUrl());
     }

--- a/src/main/java/org/example/youth_be/user/service/response/UserProfileResponse.java
+++ b/src/main/java/org/example/youth_be/user/service/response/UserProfileResponse.java
@@ -4,10 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.example.youth_be.user.domain.UserEntity;
+import org.example.youth_be.user.domain.UserLinkEntity;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
-public class UserProfileDto {
+public class UserProfileResponse {
     @Schema(description = "유저 ID")
     private Long userId;
     @Schema(description = "닉네임")
@@ -16,19 +20,25 @@ public class UserProfileDto {
     private String major;
     @Schema(description = "한 줄 소개", nullable = true)
     private String description;
+    @Schema(description = "프로필 이미지 URL", nullable = true)
+    private String profileImageUrl;
     @Schema(description = "좋아요 수")
     private Long totalLikeCount;
     @Schema(description = "팔로워 수")
     private Long followerCount;
+    @Schema(description = "유저의 외부 링크 리스트")
+    private List<LinkResponse> links;
 
-    static public UserProfileDto of(UserEntity user) {
-        return new UserProfileDto(
+    static public UserProfileResponse of(UserEntity user, List<UserLinkEntity> userLinkEntities) {
+        return new UserProfileResponse(
                 user.getUserId(),
                 user.getNickname(),
                 user.getMajor(),
                 user.getDescription(),
+                user.getProfileImageUrl(),
                 user.getTotalLikeCount(),
-                user.getFollowerCount()
+                user.getFollowerCount(),
+                userLinkEntities.stream().map(LinkResponse::of).collect(Collectors.toList())
         );
     }
 }


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
ex) feature (#8)

### 📌 작업사항
- 유저의 링크 생성 & 삭제 api를 추가합니다.
- 유저 프로필 조회 프로퍼티에 빠진 부분을 추가합니다.

### 🔥 리뷰어가 참고할 사항
