### PR TITLE
[CHUNGCUN-112] 회원가입 API, 유저 엔티티 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.2'
+    id 'org.springframework.boot' version '3.1.6'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 

--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -1,12 +1,13 @@
 package org.example.youth_be.user.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.youth_be.artwork.enums.ArtworkMyPageType;
 import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
 import org.example.youth_be.common.PageResponse;
 import org.example.youth_be.user.controller.spec.UserSpec;
 import org.example.youth_be.user.service.UserService;
-import org.example.youth_be.user.service.request.UserCreateRequest;
+import org.example.youth_be.user.service.request.UserSignupRequest;
 import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
@@ -22,8 +23,8 @@ public class UserController implements UserSpec {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Long createUser(@RequestBody UserCreateRequest request) {
-        return userService.createUser(request);
+    public Long signup(@Valid @RequestBody UserSignupRequest request) {
+        return userService.signup(request);
     }
 
     @GetMapping("/{userId}")

--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -6,7 +6,7 @@ import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
 import org.example.youth_be.common.PageResponse;
 import org.example.youth_be.user.controller.spec.UserSpec;
 import org.example.youth_be.user.service.UserService;
-import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
+import org.example.youth_be.user.service.request.UserCreateRequest;
 import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
@@ -22,8 +22,8 @@ public class UserController implements UserSpec {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Long createUserForDev(@RequestBody DevUserProfileCreateRequest request) {
-        return userService.createUserForDev(request);
+    public Long createUser(@RequestBody UserCreateRequest request) {
+        return userService.createUser(request);
     }
 
     @GetMapping("/{userId}")

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
@@ -6,7 +6,7 @@ import org.example.youth_be.artwork.enums.ArtworkMyPageType;
 import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
 import org.example.youth_be.common.ApiTags;
 import org.example.youth_be.common.PageResponse;
-import org.example.youth_be.user.service.request.UserCreateRequest;
+import org.example.youth_be.user.service.request.UserSignupRequest;
 import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
@@ -15,7 +15,7 @@ import org.example.youth_be.user.service.response.UserProfileResponse;
 @Tag(name = ApiTags.USER)
 public interface UserSpec {
     @Operation(description = "회원가입 API [값을 넣지 않으면 서버에서 임의로 넣습니다.]")
-    Long createUser(UserCreateRequest request);
+    Long signup(UserSignupRequest request);
 
     @Operation(description = "유저 프로필 조회 API")
     UserProfileResponse getUserProfile(Long userId);

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
@@ -6,7 +6,7 @@ import org.example.youth_be.artwork.enums.ArtworkMyPageType;
 import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
 import org.example.youth_be.common.ApiTags;
 import org.example.youth_be.common.PageResponse;
-import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
+import org.example.youth_be.user.service.request.UserCreateRequest;
 import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
@@ -14,8 +14,8 @@ import org.example.youth_be.user.service.response.UserProfileResponse;
 
 @Tag(name = ApiTags.USER)
 public interface UserSpec {
-    @Operation(description = "개발용 유저 생성 API [값을 넣지 않으면 서버에서 임의로 넣습니다.]")
-    Long createUserForDev(DevUserProfileCreateRequest request);
+    @Operation(description = "회원가입 API [값을 넣지 않으면 서버에서 임의로 넣습니다.]")
+    Long createUser(UserCreateRequest request);
 
     @Operation(description = "유저 프로필 조회 API")
     UserProfileResponse getUserProfile(Long userId);

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -48,7 +48,7 @@ public class UserEntity extends BaseEntity {
     private Long followerCount;
 
     @Builder
-    public UserEntity(Long userId, SocialTypeEnum socialType, String profileImageUrl, String socialId, String nickname, String activityField, String activityArea, String description, UserRoleEnum userRole, Long totalLikeCount, Long followerCount) {
+    public UserEntity(Long userId, SocialTypeEnum socialType, String profileImageUrl,String socialId, String nickname, String activityField, String activityArea, String description, UserRoleEnum userRole, Long totalLikeCount, Long followerCount) {
         this.userId = userId;
         this.socialType = socialType;
         this.profileImageUrl = profileImageUrl;

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.youth_be.common.entity.BaseEntity;
 import org.example.youth_be.user.enums.SocialTypeEnum;
+import org.example.youth_be.user.enums.UserRoleEnum;
 
 @Entity
 @Table(name = "users")
@@ -19,14 +20,19 @@ public class UserEntity extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    private UserRoleEnum userRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private SocialTypeEnum socialType;
 
     @Column(length = 1000)
     private String profileImageUrl;
 
+    @Column(nullable = false)
     private String socialId;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 50, unique = true)
     private String nickname;
 
     @Column(length = 50)
@@ -42,7 +48,7 @@ public class UserEntity extends BaseEntity {
     private Long followerCount;
 
     @Builder
-    public UserEntity(Long userId, SocialTypeEnum socialType, String profileImageUrl, String socialId, String nickname, String activityField, String activityArea, String description, Long totalLikeCount, Long followerCount) {
+    public UserEntity(Long userId, SocialTypeEnum socialType, String profileImageUrl, String socialId, String nickname, String activityField, String activityArea, String description, UserRoleEnum userRole, Long totalLikeCount, Long followerCount) {
         this.userId = userId;
         this.socialType = socialType;
         this.profileImageUrl = profileImageUrl;
@@ -51,6 +57,7 @@ public class UserEntity extends BaseEntity {
         this.activityField = activityField;
         this.activityArea = activityArea;
         this.description = description;
+        this.userRole = userRole;
         this.totalLikeCount = totalLikeCount;
         this.followerCount = followerCount;
     }

--- a/src/main/java/org/example/youth_be/user/enums/UserRoleEnum.java
+++ b/src/main/java/org/example/youth_be/user/enums/UserRoleEnum.java
@@ -1,5 +1,8 @@
 package org.example.youth_be.user.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum UserRoleEnum{
     ASSOCIATE("준회원"),
     REGULAR("정회원");
@@ -10,7 +13,4 @@ public enum UserRoleEnum{
         this.description = description;
     }
 
-    public String getDescription() {
-        return description;
-    }
 }

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -37,8 +37,7 @@ public class UserService {
                 .activityField(request.getActivityField())
                 .activityArea(request.getActivityArea())
                 .description(request.getDescription())
-//                .socialId(request.getSocialId())
-                .socialId(null)
+                .socialId(request.getSocialId())
                 .socialType(request.getSocialType())
                 .nickname(request.getNickname())
                 .build();

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -11,7 +11,7 @@ import org.example.youth_be.user.domain.UserEntity;
 import org.example.youth_be.user.domain.UserLinkEntity;
 import org.example.youth_be.user.repository.UserLinkRepository;
 import org.example.youth_be.user.repository.UserRepository;
-import org.example.youth_be.user.service.request.DevUserProfileCreateRequest;
+import org.example.youth_be.user.service.request.UserCreateRequest;
 import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
@@ -29,30 +29,19 @@ public class UserService {
     private final UserLinkRepository userLinkRepository;
     private final ArtworkRepository artworkRepository;
 
-    /**
-     * 개발용입니다.
-     */
     @Transactional
-    public Long createUserForDev(DevUserProfileCreateRequest request) {
+    public Long createUser(UserCreateRequest request) {
         UserEntity userEntity = UserEntity.builder()
+                .userRole(request.getUserRole())
                 .profileImageUrl(request.getProfileImageUrl())
                 .activityField(request.getActivityField())
                 .activityArea(request.getActivityArea())
                 .description(request.getDescription())
-                .followerCount(request.getFollowerCount())
                 .socialId(request.getSocialId())
                 .socialType(request.getSocialType())
-                .totalLikeCount(request.getTotalLikeCount())
                 .nickname(request.getNickname())
                 .build();
         userRepository.save(userEntity);
-
-        List<UserLinkEntity> userLinkEntities = request.getLinkRequestList().stream().map(linkRequest ->
-                UserLinkEntity.builder()
-                        .userId(userEntity.getUserId())
-                        .title(linkRequest.getTitle())
-                        .linkUrl(linkRequest.getUrl()).build()).toList();
-        userLinkRepository.saveAll(userLinkEntities);
         return userEntity.getUserId();
     }
 

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -11,7 +11,7 @@ import org.example.youth_be.user.domain.UserEntity;
 import org.example.youth_be.user.domain.UserLinkEntity;
 import org.example.youth_be.user.repository.UserLinkRepository;
 import org.example.youth_be.user.repository.UserRepository;
-import org.example.youth_be.user.service.request.UserCreateRequest;
+import org.example.youth_be.user.service.request.UserSignupRequest;
 import org.example.youth_be.user.service.request.LinkRequest;
 import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
@@ -30,14 +30,15 @@ public class UserService {
     private final ArtworkRepository artworkRepository;
 
     @Transactional
-    public Long createUser(UserCreateRequest request) {
+    public Long signup(UserSignupRequest request) {
         UserEntity userEntity = UserEntity.builder()
                 .userRole(request.getUserRole())
                 .profileImageUrl(request.getProfileImageUrl())
                 .activityField(request.getActivityField())
                 .activityArea(request.getActivityArea())
                 .description(request.getDescription())
-                .socialId(request.getSocialId())
+//                .socialId(request.getSocialId())
+                .socialId(null)
                 .socialType(request.getSocialType())
                 .nickname(request.getNickname())
                 .build();

--- a/src/main/java/org/example/youth_be/user/service/request/UserCreateRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/UserCreateRequest.java
@@ -1,5 +1,6 @@
 package org.example.youth_be.user.service.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.example.youth_be.user.enums.SocialTypeEnum;
 import org.example.youth_be.user.enums.UserRoleEnum;
@@ -7,16 +8,21 @@ import org.example.youth_be.user.enums.UserRoleEnum;
 import java.util.List;
 
 @Getter
-public class DevUserProfileCreateRequest {
+public class UserCreateRequest {
+    @Schema(description = "프로필 이미지 URL")
     private String profileImageUrl;
+    @Schema(description = "소셜 타입", example = "KAKAO")
     private SocialTypeEnum socialType;
+    @Schema(description = "유저 권한", example = "REGULAR")
     private UserRoleEnum userRole;
+    @Schema(description = "소셜 ID")
     private String socialId;
+    @Schema(description = "닉네임")
     private String nickname;
+    @Schema(description = "활동 분야")
     private String activityField;
+    @Schema(description = "활동 지역")
     private String activityArea;
+    @Schema(description = "소개글")
     private String description;
-    private List<LinkRequest> linkRequestList;
-    private Long totalLikeCount;
-    private Long followerCount;
 }

--- a/src/main/java/org/example/youth_be/user/service/request/UserSignupRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/UserSignupRequest.java
@@ -1,14 +1,13 @@
 package org.example.youth_be.user.service.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import org.example.youth_be.user.enums.SocialTypeEnum;
 import org.example.youth_be.user.enums.UserRoleEnum;
 
-import java.util.List;
-
 @Getter
-public class UserCreateRequest {
+public class UserSignupRequest {
     @Schema(description = "프로필 이미지 URL")
     private String profileImageUrl;
     @Schema(description = "소셜 타입", example = "KAKAO")
@@ -16,6 +15,7 @@ public class UserCreateRequest {
     @Schema(description = "유저 권한", example = "REGULAR")
     private UserRoleEnum userRole;
     @Schema(description = "소셜 ID")
+    @NotEmpty(message = "소셜 ID는 반드시 있어야 합니다")
     private String socialId;
     @Schema(description = "닉네임")
     private String nickname;

--- a/src/main/java/org/example/youth_be/user/service/response/UserProfileResponse.java
+++ b/src/main/java/org/example/youth_be/user/service/response/UserProfileResponse.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.example.youth_be.user.domain.UserEntity;
 import org.example.youth_be.user.domain.UserLinkEntity;
+import org.example.youth_be.user.enums.UserRoleEnum;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,6 +15,8 @@ import java.util.stream.Collectors;
 public class UserProfileResponse {
     @Schema(description = "유저 ID")
     private Long userId;
+    @Schema(description = "유저 권한", example = "ASSOCIATE, REGULAR")
+    private UserRoleEnum userRole;
     @Schema(description = "닉네임")
     private String nickname;
     @Schema(description = "활동 분야")
@@ -34,6 +37,7 @@ public class UserProfileResponse {
     static public UserProfileResponse of(UserEntity user, List<UserLinkEntity> userLinkEntities) {
         return new UserProfileResponse(
                 user.getUserId(),
+                user.getUserRole(),
                 user.getNickname(),
                 user.getActivityField(),
                 user.getActivityArea(),

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,8 +11,9 @@ spring:
       path: /h2-console
 
   datasource:
+    hikari:
+      jdbc-url: jdbc:h2:mem://localhost/~/youth_test
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:~/youth_test
     username: sa
     password:
 


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
[티켓](https://songminhyuk0308.atlassian.net/jira/software/projects/CHUNGCHUN/boards/2?selectedIssue=CHUNGCHUN-112)

### 📌 작업사항
- 회원 가입 과정에서 준회원, 정회원을 둘 다 받을 수 있도록 nickname을 nullable하게 변경했습니다.
- 유저 엔티티에 준회원, 정회원을 구분할 수 있는 UserRole을 추가했습니다.

### 🔥 리뷰어가 참고할 사항
- **로컬에서 h2 jdbc url이 jdbc:h2:mem://localhost/~/youth_test로 변경되었습니다**