### PR TITLE
[CHUNGCUN-92] 작품 생성, 단건 조회 api

### DIFF
--- a/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
+++ b/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
@@ -4,8 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.example.youth_be.artwork.controller.spec.ArtworkSpec;
 import org.example.youth_be.artwork.enums.ArtworkFeedType;
 import org.example.youth_be.artwork.service.ArtworkService;
+import org.example.youth_be.artwork.service.request.ArtworkCreateRequest;
 import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
 import org.example.youth_be.artwork.service.request.DevArtworkCreateRequest;
+import org.example.youth_be.artwork.service.response.ArtworkDetailResponse;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
 import org.example.youth_be.common.PageResponse;
 import org.springframework.http.HttpStatus;
@@ -20,13 +22,19 @@ public class ArtworkController implements ArtworkSpec {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Long createArtworkForDev(@RequestBody DevArtworkCreateRequest request) {
-        return artworkService.createArtworkForDev(request);
+    public Long createArtwork(@ModelAttribute ArtworkCreateRequest request) {
+        return artworkService.createArtwork(request);
     }
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public PageResponse<ArtworkResponse> getArtworks(@RequestParam Long userId, @RequestParam ArtworkFeedType type, @ModelAttribute ArtworkPaginationRequest request) {
         return artworkService.getArtworks(userId, type, request);
+    }
+
+    @GetMapping("/{artworkId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ArtworkDetailResponse getArtwork(@PathVariable Long artworkId) {
+        return artworkService.getArtwork(artworkId);
     }
 }

--- a/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
+++ b/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
@@ -11,6 +11,7 @@ import org.example.youth_be.artwork.service.response.ArtworkDetailResponse;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
 import org.example.youth_be.common.PageResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,7 +21,7 @@ public class ArtworkController implements ArtworkSpec {
 
     private final ArtworkService artworkService;
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public Long createArtwork(@ModelAttribute ArtworkCreateRequest request) {
         return artworkService.createArtwork(request);

--- a/src/main/java/org/example/youth_be/artwork/controller/spec/ArtworkSpec.java
+++ b/src/main/java/org/example/youth_be/artwork/controller/spec/ArtworkSpec.java
@@ -13,7 +13,7 @@ import org.example.youth_be.common.PageResponse;
 
 @Tag(name = ApiTags.ARTWORK)
 public interface ArtworkSpec {
-    @Operation(description = "mock 데이터 용 작품 업로드 API입니다.")
+    @Operation(description = "작품 업로드 API입니다.")
     Long createArtwork(ArtworkCreateRequest request);
 
     @Operation(description = "홈화면 피드 조회 API입니다.")

--- a/src/main/java/org/example/youth_be/artwork/controller/spec/ArtworkSpec.java
+++ b/src/main/java/org/example/youth_be/artwork/controller/spec/ArtworkSpec.java
@@ -3,8 +3,10 @@ package org.example.youth_be.artwork.controller.spec;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.example.youth_be.artwork.enums.ArtworkFeedType;
+import org.example.youth_be.artwork.service.request.ArtworkCreateRequest;
 import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
 import org.example.youth_be.artwork.service.request.DevArtworkCreateRequest;
+import org.example.youth_be.artwork.service.response.ArtworkDetailResponse;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
 import org.example.youth_be.common.ApiTags;
 import org.example.youth_be.common.PageResponse;
@@ -12,8 +14,11 @@ import org.example.youth_be.common.PageResponse;
 @Tag(name = ApiTags.ARTWORK)
 public interface ArtworkSpec {
     @Operation(description = "mock 데이터 용 작품 업로드 API입니다.")
-    Long createArtworkForDev(DevArtworkCreateRequest request);
+    Long createArtwork(ArtworkCreateRequest request);
 
     @Operation(description = "홈화면 피드 조회 API입니다.")
     PageResponse<ArtworkResponse> getArtworks(Long userId, ArtworkFeedType type, ArtworkPaginationRequest request);
+
+    @Operation(description = "작품 상세 조회 API입니다.")
+    ArtworkDetailResponse getArtwork(Long artworkId);
 }

--- a/src/main/java/org/example/youth_be/artwork/domain/ArtworkEntity.java
+++ b/src/main/java/org/example/youth_be/artwork/domain/ArtworkEntity.java
@@ -54,4 +54,8 @@ public class ArtworkEntity extends BaseEntity {
         this.likeCount = 0L;
         this.commentCount = 0L;
     }
+
+    public void setThumbnailImageUrl(String thumbnailImageUrl){
+        this.thumbnailImageUrl = thumbnailImageUrl;
+    }
 }

--- a/src/main/java/org/example/youth_be/artwork/service/ArtworkService.java
+++ b/src/main/java/org/example/youth_be/artwork/service/ArtworkService.java
@@ -4,31 +4,67 @@ import lombok.RequiredArgsConstructor;
 import org.example.youth_be.artwork.domain.ArtworkEntity;
 import org.example.youth_be.artwork.enums.ArtworkFeedType;
 import org.example.youth_be.artwork.repository.ArtworkRepository;
+import org.example.youth_be.artwork.service.request.ArtworkCreateRequest;
 import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
-import org.example.youth_be.artwork.service.request.DevArtworkCreateRequest;
+import org.example.youth_be.artwork.service.response.ArtworkDetailResponse;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
 import org.example.youth_be.common.CursorPagingCommon;
 import org.example.youth_be.common.PageResponse;
+import org.example.youth_be.common.exceptions.YouthNotFoundException;
+import org.example.youth_be.image.domain.ImageEntity;
+import org.example.youth_be.image.repository.ImageRepository;
+import org.example.youth_be.image.service.ImageService;
+import org.example.youth_be.image.service.response.UploadArtworkResponse;
+import org.example.youth_be.user.domain.UserEntity;
+import org.example.youth_be.user.repository.UserRepository;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ArtworkService {
 
     private final ArtworkRepository artworkRepository;
+    private final UserRepository userRepository;
+    private final ImageRepository imageRepository;
+    private final ImageService imageService;
 
-    /**
-     * 개발용입니다.
-     */
     @Transactional
-    public Long createArtworkForDev(DevArtworkCreateRequest request) {
-        ArtworkEntity entity = request.toEntity();
-        entity.setCount();
-        return artworkRepository.save(entity).getArtworkId();
+    public Long createArtwork(ArtworkCreateRequest request) {
+        ArtworkEntity artworkEntity = ArtworkEntity.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .artworkStatus(request.getArtworkStatus())
+                .viewCount(0L)
+                .likeCount(0L)
+                .commentCount(0L)
+                .userId(request.getUserId())
+                .build();
+        artworkRepository.save(artworkEntity);
+
+        // 이미지 업로드
+        UploadArtworkResponse uploadArtworkResponse = imageService.uploadImages(request.getImages());
+
+        // 이미지로 변환
+        List<ImageEntity> imageEntities = uploadArtworkResponse.getUrls().stream()
+                .map(url -> ImageEntity.builder()
+                        .imageUrl(url)
+                        .imageUploadName(url.substring(url.lastIndexOf('/') + 1))
+                        .artworkId(artworkEntity.getArtworkId())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 이미지 저장
+        imageRepository.saveAll(imageEntities);
+
+        // 썸네일 이미지 설정
+        artworkEntity.setThumbnailImageUrl(imageEntities.get(0).getImageUrl());
+
+        return artworkEntity.getArtworkId();
     }
 
     @Transactional(readOnly = true)
@@ -39,5 +75,14 @@ public class ArtworkService {
         List<ArtworkResponse> responses = artworkRepository.findByFeedType(userId, cursorId, size, type);
         Slice<ArtworkResponse> artworkResponses = CursorPagingCommon.getSlice(responses, size);
         return PageResponse.of(artworkResponses);
+    }
+
+    @Transactional(readOnly = true)
+    public ArtworkDetailResponse getArtwork(Long artworkId) {
+        ArtworkEntity artworkEntity = artworkRepository.findById(artworkId).orElseThrow(() -> new YouthNotFoundException("해당 ID의 작품를 찾을 수 없습니다.", null));
+        UserEntity userEntity = userRepository.findById(artworkEntity.getUserId()).orElseThrow(() -> new YouthNotFoundException("해당 ID의 유저를 찾을 수 없습니다.", null));
+        List<ImageEntity> images = imageRepository.findByArtworkId(artworkId);
+        List<String> imageUrls = images.stream().map(ImageEntity::getImageUrl).toList();
+        return ArtworkDetailResponse.of(userEntity, artworkEntity, imageUrls);
     }
 }

--- a/src/main/java/org/example/youth_be/artwork/service/request/ArtworkCreateRequest.java
+++ b/src/main/java/org/example/youth_be/artwork/service/request/ArtworkCreateRequest.java
@@ -1,0 +1,25 @@
+package org.example.youth_be.artwork.service.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.youth_be.artwork.enums.ArtworkStatus;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ArtworkCreateRequest {
+    @Schema(description = "작품 이미지 url 리스트")
+    private MultipartFile[] images;
+    @Schema(description = "작품 제목")
+    private String title;
+    @Schema(description = "작품 설명")
+    private String description;
+    @Schema(description = "작품 상태", example = "PUBLIC, SELLING, FREE")
+    private ArtworkStatus artworkStatus;
+    @Schema(description = "작품 포스팅 유저 아이디(추후에 소셜 로그인 구현 시 삭제)")
+    private Long userId;
+
+}

--- a/src/main/java/org/example/youth_be/artwork/service/response/ArtworkDetailResponse.java
+++ b/src/main/java/org/example/youth_be/artwork/service/response/ArtworkDetailResponse.java
@@ -1,0 +1,48 @@
+package org.example.youth_be.artwork.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.youth_be.artwork.domain.ArtworkEntity;
+import org.example.youth_be.artwork.enums.ArtworkStatus;
+import org.example.youth_be.user.domain.UserEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ArtworkDetailResponse {
+    private Long artworkId;
+    private String title;
+    private String description;
+    private ArtworkStatus artworkStatus;
+    private List<String> imageUrls;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    private String thumbnailImageUrl;
+    private Long artistId;
+    private String artistName;
+    private String artistProfileImageUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static ArtworkDetailResponse of(UserEntity userEntity, ArtworkEntity artworkEntity, List<String> imageUrls) {
+        return ArtworkDetailResponse.builder()
+                .artworkId(artworkEntity.getArtworkId())
+                .title(artworkEntity.getTitle())
+                .description(artworkEntity.getDescription())
+                .artworkStatus(artworkEntity.getArtworkStatus())
+                .imageUrls(imageUrls)
+                .viewCount(artworkEntity.getViewCount())
+                .likeCount(artworkEntity.getLikeCount())
+                .commentCount(artworkEntity.getCommentCount())
+                .thumbnailImageUrl(artworkEntity.getThumbnailImageUrl())
+                .artistId(userEntity.getUserId())
+                .artistName(userEntity.getNickname())
+                .artistProfileImageUrl(userEntity.getProfileImageUrl())
+                .createdAt(artworkEntity.getCreatedAt())
+                .updatedAt(artworkEntity.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/example/youth_be/common/s3/S3Properties.java
+++ b/src/main/java/org/example/youth_be/common/s3/S3Properties.java
@@ -44,5 +44,6 @@ public class S3Properties {
         @Setter
         public static class UploadDirs {
             private String profileDirName;
+            private String artworkDirName;
         }
 }

--- a/src/main/java/org/example/youth_be/image/enums/ImageType.java
+++ b/src/main/java/org/example/youth_be/image/enums/ImageType.java
@@ -1,0 +1,5 @@
+package org.example.youth_be.image.enums;
+
+public enum ImageType {
+    PROFILE, ARTWORK
+}

--- a/src/main/java/org/example/youth_be/image/repository/ImageRepository.java
+++ b/src/main/java/org/example/youth_be/image/repository/ImageRepository.java
@@ -4,6 +4,10 @@ import org.example.youth_be.image.domain.ImageEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ImageRepository extends JpaRepository<ImageEntity, Long> {
+
+    List<ImageEntity> findByArtworkId(Long artworkId);
 }

--- a/src/main/java/org/example/youth_be/image/service/ImageService.java
+++ b/src/main/java/org/example/youth_be/image/service/ImageService.java
@@ -2,9 +2,19 @@ package org.example.youth_be.image.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.youth_be.image.service.request.ImageUploadRequest;
+import org.example.youth_be.image.service.response.UploadArtworkResponse;
 import org.example.youth_be.image.service.response.UploadImageResponse;
 import org.example.youth_be.s3.service.FileUploader;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -12,8 +22,40 @@ public class ImageService {
 
     private final FileUploader fileUploader;
 
-    public UploadImageResponse uploadImage(ImageUploadRequest request) throws Exception {
-            String imageUrl = fileUploader.uploadProfileImage(request.getFile());
+    public UploadImageResponse uploadImage(ImageUploadRequest request) {
+            String imageUrl = fileUploader.upload(request.getFile());
             return UploadImageResponse.of(imageUrl);
+    }
+
+    public UploadArtworkResponse uploadImages(MultipartFile[] images) {
+        // MultipartFile 배열을 스트림으로 변환하고, 각 파일에 대해 처리
+        List<String> fileUrls = Arrays.stream(images)
+                .filter(multipartFile -> !multipartFile.isEmpty()) // 비어있지 않은 파일만 처리
+                .map(multipartFile -> {
+                    return fileUploader.upload(multipartFile);
+                })
+                .collect(Collectors.toList()); // 결과 URL을 리스트로 수집
+
+        // fileUrls에서 파일 이름만 추출
+        List<String> fileNames = fileUrls.stream()
+                .map(uploadUrl -> uploadUrl.substring(uploadUrl.lastIndexOf('/') + 1))
+                .collect(Collectors.toList());
+
+        // 결과 객체 생성 및 반환
+        return UploadArtworkResponse.builder().urls(fileUrls)
+                .fileNames(fileNames).build();
+    }
+
+    // file 로 변환해서 multipart 올릴때 사용
+    private Optional<File> convert(MultipartFile multipartFile) throws IOException {
+        File file = new File(multipartFile.getOriginalFilename());
+
+        if (file.createNewFile()){
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                fos.write(multipartFile.getBytes());
+            }
+            return Optional.of(file);
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/example/youth_be/image/service/ImageService.java
+++ b/src/main/java/org/example/youth_be/image/service/ImageService.java
@@ -1,6 +1,7 @@
 package org.example.youth_be.image.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.youth_be.image.enums.ImageType;
 import org.example.youth_be.image.service.request.ImageUploadRequest;
 import org.example.youth_be.image.service.response.UploadArtworkResponse;
 import org.example.youth_be.image.service.response.UploadImageResponse;
@@ -23,7 +24,7 @@ public class ImageService {
     private final FileUploader fileUploader;
 
     public UploadImageResponse uploadImage(ImageUploadRequest request) {
-            String imageUrl = fileUploader.upload(request.getFile());
+            String imageUrl = fileUploader.upload(request.getFile(), ImageType.PROFILE);
             return UploadImageResponse.of(imageUrl);
     }
 
@@ -32,7 +33,7 @@ public class ImageService {
         List<String> fileUrls = Arrays.stream(images)
                 .filter(multipartFile -> !multipartFile.isEmpty()) // 비어있지 않은 파일만 처리
                 .map(multipartFile -> {
-                    return fileUploader.upload(multipartFile);
+                    return fileUploader.upload(multipartFile, ImageType.ARTWORK);
                 })
                 .collect(Collectors.toList()); // 결과 URL을 리스트로 수집
 

--- a/src/main/java/org/example/youth_be/image/service/response/UploadArtworkResponse.java
+++ b/src/main/java/org/example/youth_be/image/service/response/UploadArtworkResponse.java
@@ -1,0 +1,15 @@
+package org.example.youth_be.image.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UploadArtworkResponse{
+
+    private List<String> urls;
+    private List<String> fileNames;
+
+}

--- a/src/main/java/org/example/youth_be/s3/service/FileUploader.java
+++ b/src/main/java/org/example/youth_be/s3/service/FileUploader.java
@@ -1,10 +1,11 @@
 package org.example.youth_be.s3.service;
 
+import org.example.youth_be.image.enums.ImageType;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface FileUploader {
 
-    String upload(MultipartFile file);
+    String upload(MultipartFile file, ImageType imageType);
 
     void delete(String fileName);
 }

--- a/src/main/java/org/example/youth_be/s3/service/FileUploader.java
+++ b/src/main/java/org/example/youth_be/s3/service/FileUploader.java
@@ -4,5 +4,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileUploader {
 
-    String uploadProfileImage(MultipartFile file) throws Exception;
+    String upload(MultipartFile file);
+
+    void delete(String fileName);
 }

--- a/src/main/java/org/example/youth_be/s3/service/S3FileUploader.java
+++ b/src/main/java/org/example/youth_be/s3/service/S3FileUploader.java
@@ -1,13 +1,11 @@
 package org.example.youth_be.s3.service;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.youth_be.common.exceptions.YouthBadRequestException;
-import org.example.youth_be.common.exceptions.YouthException;
 import org.example.youth_be.common.exceptions.YouthInternalException;
 import org.example.youth_be.common.s3.FileNameGenerator;
 import org.example.youth_be.common.s3.S3Properties;
@@ -16,9 +14,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.net.URL;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -31,32 +28,49 @@ public class S3FileUploader implements FileUploader {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Override
-    public String uploadProfileImage(MultipartFile file) throws Exception {
-        validateFileExists(file);
+    public String upload(MultipartFile file) {
+        try {
+            validateFileExists(file);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         String fileName = fileNameGenerator.generateName(file.getOriginalFilename(), s3Properties.getUploadDirs().getProfileDirName());
-        logger.info("s3 image upload ok. file name: {}", fileName);
-        upload(file, fileName);
 
-        return amazonS3Client.getUrl(s3Properties.getS3().getBucket(), fileName).toString();
-    }
+        try {
+            log.info("[S3 File Upload] 시작 :{}", fileName);
+            amazonS3Client.putObject(s3Properties.getS3().getBucket(), fileName, file.getInputStream(), getObjectMetadata(file));
+            log.info("[S3 File Upload] 완료 :{}", fileName);
 
-    // 업로드
-    private void upload(MultipartFile multipartFile, String fileName) throws Exception {
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentType(multipartFile.getContentType());
+            URL fileUrl = amazonS3Client.getUrl(s3Properties.getS3().getBucket(), fileName);
+            return fileUrl.toString();
 
-        try (InputStream inputStream = multipartFile.getInputStream()) {
-            BufferedInputStream bis = new BufferedInputStream(inputStream);
-            amazonS3Client.putObject(new PutObjectRequest(s3Properties.getS3().getBucket(), fileName, bis, objectMetadata)
-                    .withCannedAcl(CannedAccessControlList.PublicRead));
-        } catch (IOException e) {
-            throw new YouthInternalException("파일 업로드에 실패했습니다.", null);
+        } catch (SdkClientException | IOException e) {
+            log.error("[S3 File Upload 실패]", e);
+            throw new YouthInternalException("[S3 File Upload 실패]", e.getMessage());
         }
     }
 
+    @Override
+    public void delete(String fileName) {
+        try {
+            amazonS3Client.deleteObject(s3Properties.getS3().getBucket(), fileName);
+            log.info("[S3 File Delete] {}", fileName);
+        } catch (SdkClientException e) {
+            log.error("[S3 File Delete 실패]", e);
+            throw new YouthInternalException("[S3 File Upload 실패]", e.getMessage());
+        }
+    }
+
+    private ObjectMetadata getObjectMetadata(MultipartFile file) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(file.getContentType());
+        objectMetadata.setContentLength(file.getSize());
+        return objectMetadata;
+    }
+
     // MultipartFile이 비어있는지 확인
-    private void validateFileExists(MultipartFile multipartFile) throws Exception {
+    private void validateFileExists(MultipartFile multipartFile){
         if (multipartFile.isEmpty()) {
             throw new YouthBadRequestException("업로드할 파일이 없습니다.", null);
         }

--- a/src/main/java/org/example/youth_be/s3/service/S3FileUploader.java
+++ b/src/main/java/org/example/youth_be/s3/service/S3FileUploader.java
@@ -9,6 +9,7 @@ import org.example.youth_be.common.exceptions.YouthBadRequestException;
 import org.example.youth_be.common.exceptions.YouthInternalException;
 import org.example.youth_be.common.s3.FileNameGenerator;
 import org.example.youth_be.common.s3.S3Properties;
+import org.example.youth_be.image.enums.ImageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -28,14 +29,22 @@ public class S3FileUploader implements FileUploader {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Override
-    public String upload(MultipartFile file) {
+    public String upload(MultipartFile file, ImageType imageType) {
         try {
             validateFileExists(file);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
 
-        String fileName = fileNameGenerator.generateName(file.getOriginalFilename(), s3Properties.getUploadDirs().getProfileDirName());
+        String dirName;
+
+        if (imageType.equals(ImageType.PROFILE)) {
+            dirName = s3Properties.getUploadDirs().getProfileDirName();
+        } else {
+            dirName = s3Properties.getUploadDirs().getArtworkDirName();
+        }
+
+        String fileName = fileNameGenerator.generateName(file.getOriginalFilename(), dirName);
 
         try {
             log.info("[S3 File Upload] 시작 :{}", fileName);


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
feature (#92) [92](https://songminhyuk0308.atlassian.net/browse/CHUNGCHUN-92)

### 📌 작업사항
- 다중 이미지 업로드
- 작품 생성 api
- 작품 단건 조회 api
### 🔥 리뷰어가 참고할 사항
- 원래 작품 생성, 조회, 다중이미지 업로드를 지라티켓따라서 나눠서 작업하려했으나, 각자 겹쳐있는 부분이 존재해서 동시에 작업하게 됐어요
- 다중 이미지 업로드시 원래 비동기를 통해서 업로드 속도를 높히려고 했으나, List에 담겨야 하는 이미지의 순서가 중요한것 같기 때문에 동기방식으로 처리
- image 업로드시 file 로 변환하여 fileoutputstream으로 처리하고 upload 하는게 더 나을지? 궁금하네요
