### PR TITLE
[CHUNGCUN-110] 이미지 삭제 api(프로필 이미지가 존재하는 경우)

### DIFF
--- a/src/main/java/org/example/youth_be/image/controller/ImageController.java
+++ b/src/main/java/org/example/youth_be/image/controller/ImageController.java
@@ -3,9 +3,10 @@ package org.example.youth_be.image.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.youth_be.image.controller.spec.ImageSpec;
 import org.example.youth_be.image.service.ImageService;
+import org.example.youth_be.image.service.request.DeleteImageRequest;
 import org.example.youth_be.image.service.request.ImageUploadRequest;
+import org.example.youth_be.image.service.response.UploadImageResponse;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,7 +17,12 @@ public class ImageController implements ImageSpec {
     private final ImageService imageService;
 
     @PostMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> uploadImage(@ModelAttribute ImageUploadRequest request) throws Exception {
-        return ResponseEntity.ok(imageService.uploadImage(request));
+    public UploadImageResponse uploadImage(@ModelAttribute ImageUploadRequest request){
+        return imageService.uploadImage(request);
+    }
+
+    @DeleteMapping("/profile")
+    public void deleteImage(@RequestBody DeleteImageRequest request){
+        imageService.deleteImage(request);
     }
 }

--- a/src/main/java/org/example/youth_be/image/controller/spec/ImageSpec.java
+++ b/src/main/java/org/example/youth_be/image/controller/spec/ImageSpec.java
@@ -3,11 +3,15 @@ package org.example.youth_be.image.controller.spec;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.example.youth_be.common.ApiTags;
+import org.example.youth_be.image.service.request.DeleteImageRequest;
 import org.example.youth_be.image.service.request.ImageUploadRequest;
+import org.example.youth_be.image.service.response.UploadImageResponse;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = ApiTags.IMAGE)
 public interface ImageSpec {
     @Operation(description = "프로필 이미지 업로드 API입니다.")
-    ResponseEntity<?> uploadImage(ImageUploadRequest request) throws Exception;
+    UploadImageResponse uploadImage(ImageUploadRequest request);
+
+    void deleteImage (DeleteImageRequest request);
 }

--- a/src/main/java/org/example/youth_be/image/service/request/DeleteImageRequest.java
+++ b/src/main/java/org/example/youth_be/image/service/request/DeleteImageRequest.java
@@ -1,0 +1,13 @@
+package org.example.youth_be.image.service.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteImageRequest {
+
+
+    private Long userId;
+    private String imageUrl;
+}

--- a/src/main/java/org/example/youth_be/s3/service/S3FileUploader.java
+++ b/src/main/java/org/example/youth_be/s3/service/S3FileUploader.java
@@ -67,7 +67,7 @@ public class S3FileUploader implements FileUploader {
             log.info("[S3 File Delete] {}", fileName);
         } catch (SdkClientException e) {
             log.error("[S3 File Delete 실패]", e);
-            throw new YouthInternalException("[S3 File Upload 실패]", e.getMessage());
+            throw new YouthInternalException("[S3 File Delete 실패]", e.getMessage());
         }
     }
 

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -62,4 +62,8 @@ public class UserEntity extends BaseEntity {
         this.activityArea = activityArea;
         this.description = description;
     }
+
+    public void deleteUserProfileImageUrl(){
+        this.profileImageUrl = null;
+    }
 }


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
feature (#110)
[티켓](https://songminhyuk0308.atlassian.net/browse/CHUNGCHUN-110)

### 📌 작업사항
- 이미지 단건 삭제 api
- 이미지 url을 통해 삭제 진행
- 프로필 사진이 기존에 존재하는 경우에 삭제

### 🔥 리뷰어가 참고할 사항
- 삭제시 filename을 이용해서 삭제하는데, url에 디렉토리/파일명 구조로 filename을 꺼내서 삭제해야함
- 옛날에 좌홍님께서 이미지 삭제는 뭔가 put 처럼 하자고 했던거 같은데 혹시 맞을까요?? 저는 delete로 구현했는데, 그 이유는 프로필 이미지가 단건으로 업로드 되는 부분이라 put으로 처리하기가 애매한 느낌이 들었어요