### PR TITLE
[CHUNGCHUN-111] 링크 수정, 삭제 API

### DIFF
--- a/src/main/java/org/example/youth_be/common/jwt/TokenClaim.java
+++ b/src/main/java/org/example/youth_be/common/jwt/TokenClaim.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.example.youth_be.user.enums.UserRoleEnum;
 
+import java.util.Objects;
+
 import static org.example.youth_be.common.jwt.TokenProvider.KEY_USER_ID;
 import static org.example.youth_be.common.jwt.TokenProvider.KEY_USER_ROLE;
 
@@ -26,5 +28,9 @@ public class TokenClaim {
                 claims.getIssuedAt().toInstant().getEpochSecond(),
                 claims.getExpiration().getTime(),
                 UserRoleEnum.fromValue((String) claims.get(KEY_USER_ROLE)));
+    }
+
+    public boolean isNotAuthorized(Long userId) {
+        return !Objects.equals(this.userId, userId);
     }
 }

--- a/src/main/java/org/example/youth_be/common/util/DebuggingTemplate.java
+++ b/src/main/java/org/example/youth_be/common/util/DebuggingTemplate.java
@@ -1,0 +1,11 @@
+package org.example.youth_be.common.util;
+
+import org.example.youth_be.common.jwt.TokenClaim;
+
+public class DebuggingTemplate {
+    public static String NotAuthorized(Long userId, TokenClaim claim) {
+        return """
+                    권한이 없는 사용자입니다. userId: %d, tokenUserId: %d
+                    """.formatted(userId, claim.getUserId());
+    }
+}

--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -9,10 +9,7 @@ import org.example.youth_be.common.PageResponse;
 import org.example.youth_be.common.jwt.TokenClaim;
 import org.example.youth_be.user.controller.spec.UserSpec;
 import org.example.youth_be.user.service.UserService;
-import org.example.youth_be.user.service.request.UserAdditionSignupRequest;
-import org.example.youth_be.user.service.request.UserSignupRequest;
-import org.example.youth_be.user.service.request.LinkRequest;
-import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
+import org.example.youth_be.user.service.request.*;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
 import org.example.youth_be.user.service.response.UserMyInformation;
 import org.example.youth_be.user.service.response.UserMyPage;
@@ -61,6 +58,13 @@ public class UserController implements UserSpec {
     @ResponseStatus(HttpStatus.OK)
     public void deleteUserLink(@PathVariable Long userId, @PathVariable Long linkId) {
         userService.deleteUserLink(userId, linkId);
+    }
+
+    @Override
+    @PutMapping("/{userId}/links/{linkId}")
+    @ResponseStatus(HttpStatus.OK)
+    public Long updateUserLink(@PathVariable Long userId, @PathVariable Long linkId, @RequestBody UserLinkUpdateRequest request) {
+        return userService.updateUserLink(userId, linkId, request);
     }
 
     @GetMapping("/{userId}/artworks")

--- a/src/main/java/org/example/youth_be/user/controller/UserController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserController.java
@@ -24,67 +24,77 @@ import org.springframework.web.bind.annotation.*;
 public class UserController implements UserSpec {
     private final UserService userService;
 
+    @Override
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public Long signup(@Valid @RequestBody UserSignupRequest request) {
         return userService.signup(request);
     }
 
+    @Override
     @GetMapping("/check")
     @ResponseStatus(HttpStatus.OK)
     public void checkNicknameDuplicate(@RequestParam String nickname) {
         userService.checkNicknameDuplicate(nickname);
     }
 
+    @Override
     @GetMapping("/{userId}")
     @ResponseStatus(HttpStatus.OK)
     public UserProfileResponse getUserProfile(@PathVariable Long userId) {
         return userService.getUserProfile(userId);
     }
 
+    @Override
     @PutMapping("/{userId}")
     @ResponseStatus(HttpStatus.OK)
     public void updateUserProfile(@PathVariable Long userId, @RequestBody UserProfileUpdateRequest request) {
         userService.updateUserProfile(userId, request);
     }
 
+    @Override
     @PostMapping("/{userId}/links")
     @ResponseStatus(HttpStatus.CREATED)
-    public Long createUserLink(@PathVariable Long userId, @RequestBody LinkRequest request) {
-        return userService.createUserLink(userId, request);
+    public Long createUserLink(@PathVariable Long userId, @RequestBody LinkRequest request, @CurrentUser TokenClaim claim) {
+        return userService.createUserLink(userId, request, claim);
     }
 
+    @Override
     @DeleteMapping("/{userId}/links/{linkId}")
     @ResponseStatus(HttpStatus.OK)
-    public void deleteUserLink(@PathVariable Long userId, @PathVariable Long linkId) {
-        userService.deleteUserLink(userId, linkId);
+    public void deleteUserLink(@PathVariable Long userId, @PathVariable Long linkId, @CurrentUser TokenClaim claim) {
+        userService.deleteUserLink(userId, linkId, claim);
     }
 
     @Override
     @PutMapping("/{userId}/links/{linkId}")
     @ResponseStatus(HttpStatus.OK)
-    public Long updateUserLink(@PathVariable Long userId, @PathVariable Long linkId, @RequestBody UserLinkUpdateRequest request) {
-        return userService.updateUserLink(userId, linkId, request);
+    public Long updateUserLink(@PathVariable Long userId, @PathVariable Long linkId, @RequestBody UserLinkUpdateRequest request, @CurrentUser TokenClaim claim) {
+        return userService.updateUserLink(userId, linkId, request, claim);
     }
 
+    @Override
     @GetMapping("/{userId}/artworks")
     @ResponseStatus(HttpStatus.OK)
     public PageResponse<ArtworkResponse> getUserArtworks(@PathVariable Long userId, @RequestParam ArtworkMyPageType type, @ModelAttribute ArtworkPaginationRequest request) {
         return userService.getUserArtworks(userId, type, request);
     }
 
+    @Override
     @GetMapping("/me")
     @ResponseStatus(HttpStatus.OK)
     public UserMyInformation getMyInformation(@CurrentUser TokenClaim tokenClaim) {
         return userService.getMyInformation(tokenClaim);
     }
 
+    @Override
     @PutMapping("/sign-up")
     @ResponseStatus(HttpStatus.OK)
     public UserSignUpResponse signUp(@CurrentUser TokenClaim tokenClaim, @RequestBody UserAdditionSignupRequest request) {
         return userService.signUp(tokenClaim, request);
     }
 
+    @Override
     @GetMapping("/mypage")
     @ResponseStatus(HttpStatus.OK)
     public UserMyPage getMyPage(@CurrentUser TokenClaim tokenClaim) {

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
@@ -4,19 +4,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.example.youth_be.artwork.enums.ArtworkMyPageType;
 import org.example.youth_be.artwork.service.request.ArtworkPaginationRequest;
+import org.example.youth_be.artwork.service.response.ArtworkResponse;
 import org.example.youth_be.common.ApiTags;
 import org.example.youth_be.common.PageResponse;
 import org.example.youth_be.common.jwt.TokenClaim;
-import org.example.youth_be.user.service.request.UserAdditionSignupRequest;
-import org.example.youth_be.user.service.request.UserSignupRequest;
-import org.example.youth_be.user.service.request.LinkRequest;
-import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
-import org.example.youth_be.artwork.service.response.ArtworkResponse;
+import org.example.youth_be.user.service.request.*;
 import org.example.youth_be.user.service.response.UserMyInformation;
 import org.example.youth_be.user.service.response.UserMyPage;
 import org.example.youth_be.user.service.response.UserProfileResponse;
 import org.example.youth_be.user.service.response.UserSignUpResponse;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = ApiTags.USER)
 public interface UserSpec {
@@ -37,6 +33,9 @@ public interface UserSpec {
 
     @Operation(description = "유저 링크 삭제 API")
     void deleteUserLink(Long userId, Long linkId);
+
+    @Operation(description = "유저 링크 수정 API \n\nNote: 수정된 링크 ID를 반환합니다")
+    Long updateUserLink(Long userId, Long linkId, UserLinkUpdateRequest request);
 
     @Operation(description = "유저의 작품 조회 API")
     PageResponse<ArtworkResponse> getUserArtworks(Long userId, ArtworkMyPageType type, ArtworkPaginationRequest request);

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserSpec.java
@@ -29,13 +29,13 @@ public interface UserSpec {
     void updateUserProfile(Long userId, UserProfileUpdateRequest request);
 
     @Operation(description = "유저 링크 생성 API")
-    Long createUserLink(Long userId, LinkRequest request);
+    Long createUserLink(Long userId, LinkRequest request, TokenClaim claim);
 
     @Operation(description = "유저 링크 삭제 API")
-    void deleteUserLink(Long userId, Long linkId);
+    void deleteUserLink(Long userId, Long linkId, TokenClaim claim);
 
     @Operation(description = "유저 링크 수정 API \n\nNote: 수정된 링크 ID를 반환합니다")
-    Long updateUserLink(Long userId, Long linkId, UserLinkUpdateRequest request);
+    Long updateUserLink(Long userId, Long linkId, UserLinkUpdateRequest request, TokenClaim claim);
 
     @Operation(description = "유저의 작품 조회 API")
     PageResponse<ArtworkResponse> getUserArtworks(Long userId, ArtworkMyPageType type, ArtworkPaginationRequest request);

--- a/src/main/java/org/example/youth_be/user/domain/UserLinkEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserLinkEntity.java
@@ -29,4 +29,9 @@ public class UserLinkEntity {
         this.title = title;
         this.linkUrl = linkUrl;
     }
+
+    public void updateLink(String title, String linkUrl) {
+        this.title = title;
+        this.linkUrl = linkUrl;
+    }
 }

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -29,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static org.example.youth_be.common.util.DebuggingTemplate.NotAuthorized;
+
 @Service
 public class UserService {
     private final UserRepository userRepository;
@@ -77,9 +79,7 @@ public class UserService {
     @Transactional
     public Long createUserLink(Long userId, LinkRequest request, TokenClaim claim) {
         if (claim.isNotAuthorized(userId)) {
-            throw new YouthBadRequestException("권한이 없는 사용자입니다.", """
-                    권한이 없는 사용자입니다. userId: %d, tokenUserId: %d
-                    """.formatted(userId, claim.getUserId()));
+            throw new YouthBadRequestException("권한이 없는 사용자입니다.", NotAuthorized(userId, claim));
         }
         userRepository.findById(userId).orElseThrow(() -> new YouthNotFoundException("해당 ID의 유저를 찾을 수 없습니다.", null));
         UserLinkEntity newUserLinkEntity = UserLinkEntity.builder()
@@ -95,9 +95,7 @@ public class UserService {
     @Transactional
     public Long updateUserLink(Long userId, Long linkId, UserLinkUpdateRequest request, TokenClaim claim) {
         if (claim.isNotAuthorized(userId)) {
-            throw new YouthBadRequestException("권한이 없는 사용자입니다.", """
-                    권한이 없는 사용자입니다. userId: %d, tokenUserId: %d
-                    """.formatted(userId, claim.getUserId()));
+            throw new YouthBadRequestException("권한이 없는 사용자입니다.", NotAuthorized(userId, claim));
         }
         UserLinkEntity userLinkEntity = userLinkRepository.findByIdAndUserId(linkId, userId).orElseThrow(() -> new YouthNotFoundException("링크를 찾을 수 없습니다", null));
         userLinkEntity.updateLink(request.getTitle(), request.getUrl());
@@ -107,9 +105,7 @@ public class UserService {
     @Transactional
     public void deleteUserLink(Long userId, Long linkId, TokenClaim claim) {
         if (claim.isNotAuthorized(userId)) {
-            throw new YouthBadRequestException("권한이 없는 사용자입니다.", """
-                    권한이 없는 사용자입니다. userId: %d, tokenUserId: %d
-                    """.formatted(userId, claim.getUserId()));
+            throw new YouthBadRequestException("권한이 없는 사용자입니다.", NotAuthorized(userId, claim));
         }
         userLinkRepository.findByIdAndUserId(linkId, claim.getUserId()).orElseThrow(() -> new YouthNotFoundException("링크를 찾을 수 없습니다", null));
         userLinkRepository.deleteById(linkId);

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -104,8 +104,6 @@ public class UserService {
         return userLinkEntity.getId();
     }
 
-    // 이미지 삭제
-
     @Transactional
     public void deleteUserLink(Long userId, Long linkId, TokenClaim claim) {
         if (claim.isNotAuthorized(userId)) {

--- a/src/main/java/org/example/youth_be/user/service/UserService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserService.java
@@ -15,10 +15,7 @@ import org.example.youth_be.user.domain.UserLinkEntity;
 import org.example.youth_be.user.enums.UserRoleEnum;
 import org.example.youth_be.user.repository.UserLinkRepository;
 import org.example.youth_be.user.repository.UserRepository;
-import org.example.youth_be.user.service.request.UserAdditionSignupRequest;
-import org.example.youth_be.user.service.request.UserSignupRequest;
-import org.example.youth_be.user.service.request.LinkRequest;
-import org.example.youth_be.user.service.request.UserProfileUpdateRequest;
+import org.example.youth_be.user.service.request.*;
 import org.example.youth_be.artwork.service.response.ArtworkResponse;
 import org.example.youth_be.user.service.response.UserMyInformation;
 import org.example.youth_be.user.service.response.UserMyPage;
@@ -89,6 +86,13 @@ public class UserService {
     }
 
     // 링크 수정
+    @Transactional
+    public Long updateUserLink(Long userId, Long linkId, UserLinkUpdateRequest request) {
+        UserLinkEntity userLinkEntity = userLinkRepository.findByIdAndUserId(linkId, userId).orElseThrow(() -> new YouthNotFoundException("링크를 찾을 수 없습니다", null));
+        userLinkEntity.updateLink(request.getTitle(), request.getUrl());
+        return userLinkEntity.getId();
+    }
+
     // 이미지 삭제
 
     @Transactional

--- a/src/main/java/org/example/youth_be/user/service/request/UserLinkUpdateRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/UserLinkUpdateRequest.java
@@ -1,0 +1,14 @@
+package org.example.youth_be.user.service.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserLinkUpdateRequest {
+    @Schema(description = "링크 제목")
+    private String title;
+    @Schema(description = "링크 URL")
+    private String url;
+}


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
ex) feature (#8)
[티켓](https://songminhyuk0308.atlassian.net/jira/software/projects/CHUNGCHUN/boards/2?issueParent=10088&selectedIssue=CHUNGCHUN-111&sprints=5%2C6)

### 📌 작업사항
- 링크 생성, 수정, 삭제 api 내부에서 userId path variable과 토큰에서 얻은 claim의 userId를 비교하여 다르면 권한 예외를 발생시키도록 수정했습니다.
- 링크 수정 api를 생성하였습니다.
- 인터페이스의 시그니처와 다른 경우 에러를 바로 알 수 있도록 UserController에 Override 어노테이션을 추가했습니다.

### 🔥 리뷰어가 참고할 사항
