### PR TITLE
[CHUNGCHUN-127] 토큰 재발급 API 및 시큐리티 설정 + 로그인 API 변경

### DIFF
--- a/src/main/java/org/example/youth_be/common/ApiTags.java
+++ b/src/main/java/org/example/youth_be/common/ApiTags.java
@@ -2,6 +2,7 @@ package org.example.youth_be.common;
 
 public class ApiTags {
     public static final String USER = "유저 API";
+    public static final String USER_AUTH = "유저 인증 API";
     public static final String IMAGE = "이미지 업로드 API";
 
     public static final String ARTWORK = "작품 API";

--- a/src/main/java/org/example/youth_be/common/jwt/AccessTokenProvider.java
+++ b/src/main/java/org/example/youth_be/common/jwt/AccessTokenProvider.java
@@ -1,14 +1,13 @@
 package org.example.youth_be.common.jwt;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.apache.commons.lang3.StringUtils;
-import org.example.youth_be.common.exceptions.YouthBadRequestException;
-import org.example.youth_be.common.exceptions.YouthNotFoundException;
-import org.example.youth_be.user.domain.UserEntity;
 import org.example.youth_be.user.enums.UserRoleEnum;
-import org.example.youth_be.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -45,6 +44,21 @@ public class AccessTokenProvider implements TokenProvider {
         ZoneId KST = ZoneId.of("Asia/Seoul");
         ZonedDateTime issuedAt = ZonedDateTime.now(KST).truncatedTo(ChronoUnit.SECONDS);
         ZonedDateTime expiration = issuedAt.plusDays(jwtProperties.getAccessValidityInDays());
+        return Jwts.builder()
+                .claim(KEY_USER_ID, userId)
+                .claim(KEY_USER_ROLE, userRole)
+                .setSubject(SUBJECT_ACCESS_TOKEN)
+                .setIssuedAt(Date.from(issuedAt.toInstant()))
+                .setExpiration(Date.from(expiration.toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    @Override
+    public String generateTokenForDev(Long userId, UserRoleEnum userRole, Long validityInSeconds) {
+        ZoneId KST = ZoneId.of("Asia/Seoul");
+        ZonedDateTime issuedAt = ZonedDateTime.now(KST).truncatedTo(ChronoUnit.SECONDS);
+        ZonedDateTime expiration = issuedAt.plusSeconds(validityInSeconds);
         return Jwts.builder()
                 .claim(KEY_USER_ID, userId)
                 .claim(KEY_USER_ROLE, userRole)

--- a/src/main/java/org/example/youth_be/common/jwt/ParsedTokenInfo.java
+++ b/src/main/java/org/example/youth_be/common/jwt/ParsedTokenInfo.java
@@ -8,4 +8,16 @@ import lombok.Getter;
 public class ParsedTokenInfo {
     private TokenClaim tokenClaim;
     private JwtThrowableType throwableType;
+
+    public boolean isExpired() {
+        return throwableType == JwtThrowableType.EXPIRED;
+    }
+
+    public boolean isSameUserId(ParsedTokenInfo tokenInfo) {
+        return tokenInfo.tokenClaim.getUserId().equals(this.tokenClaim.getUserId());
+    }
+
+    public boolean isNormalToken() {
+        return throwableType == null;
+    }
 }

--- a/src/main/java/org/example/youth_be/common/jwt/RefreshTokenProvider.java
+++ b/src/main/java/org/example/youth_be/common/jwt/RefreshTokenProvider.java
@@ -52,4 +52,19 @@ public class RefreshTokenProvider implements TokenProvider {
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
+
+    @Override
+    public String generateTokenForDev(Long userId, UserRoleEnum userRole, Long validityInSeconds) {
+        ZoneId KST = ZoneId.of("Asia/Seoul");
+        ZonedDateTime issuedAt = ZonedDateTime.now(KST).truncatedTo(ChronoUnit.SECONDS);
+        ZonedDateTime expiration = issuedAt.plusSeconds(validityInSeconds);
+        return Jwts.builder()
+                .claim(KEY_USER_ID, userId)
+                .claim(KEY_USER_ROLE, userRole)
+                .setSubject(SUBJECT_REFRESH_TOKEN)
+                .setIssuedAt(Date.from(issuedAt.toInstant()))
+                .setExpiration(Date.from(expiration.toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
 }

--- a/src/main/java/org/example/youth_be/common/jwt/TokenProvider.java
+++ b/src/main/java/org/example/youth_be/common/jwt/TokenProvider.java
@@ -12,6 +12,7 @@ public interface TokenProvider {
     String KEY_USER_ROLE = "user_role";
     TokenClaim getClaim(String token);
     String generateToken(Long userId, UserRoleEnum userRole);
+    String generateTokenForDev(Long userId, UserRoleEnum userRole, Long validityInSeconds);
     default ParsedTokenInfo parseToken(String token) {
         try {
             TokenClaim tokenClaim = getClaim(token);

--- a/src/main/java/org/example/youth_be/common/security/SecurityConfig.java
+++ b/src/main/java/org/example/youth_be/common/security/SecurityConfig.java
@@ -72,10 +72,7 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers(PathRequest.toH2Console()).permitAll()
                         .requestMatchers(Stream.of(PATTERNS).map(AntPathRequestMatcher::antMatcher).toArray(AntPathRequestMatcher[]::new)).permitAll()
-                        .requestMatchers(antMatcher("/swagger-ui/**")).permitAll()
-                        .requestMatchers(antMatcher("/login")).permitAll()
                         .requestMatchers(antMatcher(HttpMethod.GET, "/artworks/**")).permitAll()
                         .requestMatchers(antMatcher(HttpMethod.GET, "/users/{userId}")).permitAll()
                         .requestMatchers(antMatcher(HttpMethod.GET, "/users/{userId}/artworks")).permitAll() // 회원이 아니어도 접근 가능

--- a/src/main/java/org/example/youth_be/user/controller/UserAuthController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserAuthController.java
@@ -1,20 +1,37 @@
 package org.example.youth_be.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.youth_be.user.controller.spec.UserAuthSpec;
 import org.example.youth_be.user.service.UserAuthService;
+import org.example.youth_be.user.service.request.DevTokenGenerateRequest;
 import org.example.youth_be.user.service.request.LoginRequest;
+import org.example.youth_be.user.service.request.TokenReissueRequest;
 import org.example.youth_be.user.service.response.LoginResponse;
+import org.example.youth_be.user.service.response.TokenReissueResponse;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class UserAuthController {
+public class UserAuthController implements UserAuthSpec {
     private final UserAuthService userAuthService;
 
+    @Override
     @PostMapping("/login")
     public LoginResponse login(@RequestBody LoginRequest request) {
         return userAuthService.login(request);
+    }
+
+    @Override
+    @PostMapping("/reissue")
+    public TokenReissueResponse reissue(@RequestBody TokenReissueRequest request) {
+        return userAuthService.reissue(request);
+    }
+
+    @Override
+    @PostMapping("/dev-tokens")
+    public TokenReissueResponse generatedTokensForDev(@RequestBody DevTokenGenerateRequest request) {
+        return userAuthService.generateForDev(request);
     }
 }

--- a/src/main/java/org/example/youth_be/user/controller/UserAuthController.java
+++ b/src/main/java/org/example/youth_be/user/controller/UserAuthController.java
@@ -6,6 +6,7 @@ import org.example.youth_be.user.service.UserAuthService;
 import org.example.youth_be.user.service.request.DevTokenGenerateRequest;
 import org.example.youth_be.user.service.request.LoginRequest;
 import org.example.youth_be.user.service.request.TokenReissueRequest;
+import org.example.youth_be.user.service.response.GenerateTokensForDev;
 import org.example.youth_be.user.service.response.LoginResponse;
 import org.example.youth_be.user.service.response.TokenReissueResponse;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,7 +32,7 @@ public class UserAuthController implements UserAuthSpec {
 
     @Override
     @PostMapping("/dev-tokens")
-    public TokenReissueResponse generatedTokensForDev(@RequestBody DevTokenGenerateRequest request) {
+    public GenerateTokensForDev generatedTokensForDev(@RequestBody DevTokenGenerateRequest request) {
         return userAuthService.generateForDev(request);
     }
 }

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserAuthSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserAuthSpec.java
@@ -1,0 +1,20 @@
+package org.example.youth_be.user.controller.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.youth_be.common.ApiTags;
+import org.example.youth_be.user.service.request.DevTokenGenerateRequest;
+import org.example.youth_be.user.service.request.LoginRequest;
+import org.example.youth_be.user.service.request.TokenReissueRequest;
+import org.example.youth_be.user.service.response.LoginResponse;
+import org.example.youth_be.user.service.response.TokenReissueResponse;
+
+@Tag(name = ApiTags.USER_AUTH)
+public interface UserAuthSpec {
+    @Operation(description = "로그인 API")
+    LoginResponse login(LoginRequest request);
+    @Operation(description = "토큰 재발급 API")
+    TokenReissueResponse reissue(TokenReissueRequest request);
+    @Operation(description = "개발용 토큰 재발급 API\n\n만료시간은 초 단위입니다.")
+    TokenReissueResponse generatedTokensForDev(DevTokenGenerateRequest request);
+}

--- a/src/main/java/org/example/youth_be/user/controller/spec/UserAuthSpec.java
+++ b/src/main/java/org/example/youth_be/user/controller/spec/UserAuthSpec.java
@@ -6,6 +6,7 @@ import org.example.youth_be.common.ApiTags;
 import org.example.youth_be.user.service.request.DevTokenGenerateRequest;
 import org.example.youth_be.user.service.request.LoginRequest;
 import org.example.youth_be.user.service.request.TokenReissueRequest;
+import org.example.youth_be.user.service.response.GenerateTokensForDev;
 import org.example.youth_be.user.service.response.LoginResponse;
 import org.example.youth_be.user.service.response.TokenReissueResponse;
 
@@ -16,5 +17,5 @@ public interface UserAuthSpec {
     @Operation(description = "토큰 재발급 API")
     TokenReissueResponse reissue(TokenReissueRequest request);
     @Operation(description = "개발용 토큰 재발급 API\n\n만료시간은 초 단위입니다.")
-    TokenReissueResponse generatedTokensForDev(DevTokenGenerateRequest request);
+    GenerateTokensForDev generatedTokensForDev(DevTokenGenerateRequest request);
 }

--- a/src/main/java/org/example/youth_be/user/enums/SocialTypeEnum.java
+++ b/src/main/java/org/example/youth_be/user/enums/SocialTypeEnum.java
@@ -1,5 +1,5 @@
 package org.example.youth_be.user.enums;
 
 public enum SocialTypeEnum {
-    GOOGLE, KAKAO
+    NAVER, KAKAO
 }

--- a/src/main/java/org/example/youth_be/user/repository/UserCustomRepository.java
+++ b/src/main/java/org/example/youth_be/user/repository/UserCustomRepository.java
@@ -1,0 +1,10 @@
+package org.example.youth_be.user.repository;
+
+import org.example.youth_be.user.domain.UserEntity;
+import org.example.youth_be.user.enums.SocialTypeEnum;
+
+import java.util.Optional;
+
+interface UserCustomRepository {
+    Optional<UserEntity> findBySocialIdAndSocialType(String socialId, SocialTypeEnum socialType);
+}

--- a/src/main/java/org/example/youth_be/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/org/example/youth_be/user/repository/UserCustomRepositoryImpl.java
@@ -1,0 +1,25 @@
+package org.example.youth_be.user.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.youth_be.user.domain.QUserEntity;
+import org.example.youth_be.user.domain.UserEntity;
+import org.example.youth_be.user.enums.SocialTypeEnum;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository{
+    private final JPAQueryFactory jpaQueryFactory;
+    private QUserEntity userEntity = QUserEntity.userEntity;
+
+    @Override
+    public Optional<UserEntity> findBySocialIdAndSocialType(String socialId, SocialTypeEnum socialType) {
+        return Optional.ofNullable(jpaQueryFactory.select(userEntity)
+                .from(userEntity)
+                .where(
+                        userEntity.socialId.eq(socialId),
+                        userEntity.socialType.eq(socialType)
+                ).fetchOne());
+    }
+}

--- a/src/main/java/org/example/youth_be/user/repository/UserRepository.java
+++ b/src/main/java/org/example/youth_be/user/repository/UserRepository.java
@@ -1,14 +1,10 @@
 package org.example.youth_be.user.repository;
 
 import org.example.youth_be.user.domain.UserEntity;
-import org.example.youth_be.user.enums.SocialTypeEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
-public interface UserRepository extends JpaRepository<UserEntity, Long>{
+public interface UserRepository extends JpaRepository<UserEntity, Long>, UserCustomRepository{
     boolean existsByNickname(String nickname);
-    Optional<UserEntity> findBySocialIdAndSocialType(String socialId, SocialTypeEnum socialType);
 }

--- a/src/main/java/org/example/youth_be/user/service/UserAuthService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserAuthService.java
@@ -2,12 +2,18 @@ package org.example.youth_be.user.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.youth_be.common.exceptions.YouthBadRequestException;
+import org.example.youth_be.common.exceptions.YouthForbiddenException;
 import org.example.youth_be.common.exceptions.YouthNotFoundException;
+import org.example.youth_be.common.jwt.ParsedTokenInfo;
 import org.example.youth_be.common.jwt.TokenProvider;
 import org.example.youth_be.user.domain.UserEntity;
 import org.example.youth_be.user.repository.UserRepository;
+import org.example.youth_be.user.service.request.DevTokenGenerateRequest;
 import org.example.youth_be.user.service.request.LoginRequest;
+import org.example.youth_be.user.service.request.TokenReissueRequest;
 import org.example.youth_be.user.service.response.LoginResponse;
+import org.example.youth_be.user.service.response.TokenReissueResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,5 +32,46 @@ public class UserAuthService {
         String accessToken = accessTokenProvider.generateToken(userEntity.getUserId(), userEntity.getUserRole());
         String refreshToken = refreshTokenProvider.generateToken(userEntity.getUserId(), userEntity.getUserRole());
         return new LoginResponse(accessToken, refreshToken, userEntity.getUserRole());
+    }
+
+    @Transactional(readOnly = true)
+    public TokenReissueResponse reissue(TokenReissueRequest request) {
+        ParsedTokenInfo accessTokenInfo = accessTokenProvider.parseToken(request.getAccessToken());
+        ParsedTokenInfo refreshTokenInfo = refreshTokenProvider.parseToken(request.getRefreshToken());
+
+        validateAccessToken(accessTokenInfo);
+        validateRefreshToken(refreshTokenInfo);
+        if (!accessTokenInfo.isSameUserId(refreshTokenInfo)) {
+            throw new YouthBadRequestException("리프레시, 액세스 토큰이 일치하지 않습니다.", null);
+        }
+
+        UserEntity userEntity = userRepository.findById(accessTokenInfo.getTokenClaim().getUserId())
+                .orElseThrow(() -> new YouthNotFoundException("유저를 찾을 수 없습니다.", null));
+        String generatedAccessToken = accessTokenProvider.generateToken(userEntity.getUserId(), userEntity.getUserRole());
+        String generatedRefreshToken = refreshTokenProvider.generateToken(userEntity.getUserId(), userEntity.getUserRole());
+        return new TokenReissueResponse(generatedAccessToken, generatedRefreshToken);
+    }
+
+    @Transactional(readOnly = true)
+    public TokenReissueResponse generateForDev(DevTokenGenerateRequest request) {
+        String generatedAccessToken = accessTokenProvider.generateTokenForDev(request.getUserId(), request.getUserRole(), request.getAccessValidityInSeconds());
+        String generatedRefreshToken = refreshTokenProvider.generateTokenForDev(request.getUserId(), request.getUserRole(), request.getRefreshValidityInSeconds());
+        return new TokenReissueResponse(generatedAccessToken, generatedRefreshToken);
+    }
+
+    private void validateRefreshToken(ParsedTokenInfo refreshTokenInfo) {
+        if (refreshTokenInfo.isExpired()) {
+            throw new YouthForbiddenException("리프레시 토큰이 만료되었습니다.", "리프레시 토큰이 만료되었습니다.");
+        }
+        if (!refreshTokenInfo.isNormalToken()) {
+            throw new YouthBadRequestException("올바르지 않은 리프레시 토큰입니다.", null);
+        }
+    }
+
+    private void validateAccessToken(ParsedTokenInfo accessTokenInfo) {
+        if (!accessTokenInfo.isExpired()) {
+            throw new YouthBadRequestException("만료되지 않았거나 올바르지 않은 토큰입니다.", """
+                    만료되지 않았거나 올바르지 않은 토큰입니다. userId: %d""".formatted(accessTokenInfo.getTokenClaim().getUserId()));
+        }
     }
 }

--- a/src/main/java/org/example/youth_be/user/service/UserAuthService.java
+++ b/src/main/java/org/example/youth_be/user/service/UserAuthService.java
@@ -13,6 +13,7 @@ import org.example.youth_be.user.repository.UserRepository;
 import org.example.youth_be.user.service.request.DevTokenGenerateRequest;
 import org.example.youth_be.user.service.request.LoginRequest;
 import org.example.youth_be.user.service.request.TokenReissueRequest;
+import org.example.youth_be.user.service.response.GenerateTokensForDev;
 import org.example.youth_be.user.service.response.LoginResponse;
 import org.example.youth_be.user.service.response.TokenReissueResponse;
 import org.springframework.stereotype.Service;
@@ -55,15 +56,14 @@ public class UserAuthService {
         UserEntity userEntity = userRepository.findById(accessTokenInfo.getTokenClaim().getUserId())
                 .orElseThrow(() -> new YouthNotFoundException("유저를 찾을 수 없습니다.", null));
         String generatedAccessToken = accessTokenProvider.generateToken(userEntity.getUserId(), userEntity.getUserRole());
-        String generatedRefreshToken = refreshTokenProvider.generateToken(userEntity.getUserId(), userEntity.getUserRole());
-        return new TokenReissueResponse(generatedAccessToken, generatedRefreshToken);
+        return new TokenReissueResponse(generatedAccessToken);
     }
 
     @Transactional(readOnly = true)
-    public TokenReissueResponse generateForDev(DevTokenGenerateRequest request) {
+    public GenerateTokensForDev generateForDev(DevTokenGenerateRequest request) {
         String generatedAccessToken = accessTokenProvider.generateTokenForDev(request.getUserId(), request.getUserRole(), request.getAccessValidityInSeconds());
         String generatedRefreshToken = refreshTokenProvider.generateTokenForDev(request.getUserId(), request.getUserRole(), request.getRefreshValidityInSeconds());
-        return new TokenReissueResponse(generatedAccessToken, generatedRefreshToken);
+        return new GenerateTokensForDev(generatedAccessToken, generatedRefreshToken);
     }
 
     private void validateRefreshToken(ParsedTokenInfo refreshTokenInfo) {

--- a/src/main/java/org/example/youth_be/user/service/request/DevTokenGenerateRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/DevTokenGenerateRequest.java
@@ -1,0 +1,19 @@
+package org.example.youth_be.user.service.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.youth_be.user.enums.UserRoleEnum;
+
+@Getter
+@AllArgsConstructor
+public class DevTokenGenerateRequest {
+    @Schema(description = "유저 ID")
+    private Long userId;
+    @Schema(description = "유저 역할")
+    private UserRoleEnum userRole;
+    @Schema(description = "액세스 토큰 만료 시간 (초 단위)")
+    private Long accessValidityInSeconds;
+    @Schema(description = "리프레시 토큰 만료 시간 (초 단위)")
+    private Long refreshValidityInSeconds;
+}

--- a/src/main/java/org/example/youth_be/user/service/request/TokenReissueRequest.java
+++ b/src/main/java/org/example/youth_be/user/service/request/TokenReissueRequest.java
@@ -1,0 +1,14 @@
+package org.example.youth_be.user.service.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenReissueRequest {
+    @Schema(description = "만료된 액세스 토큰")
+    private String accessToken;
+    @Schema(description = "리프레시 토큰")
+    private String refreshToken;
+}

--- a/src/main/java/org/example/youth_be/user/service/response/GenerateTokensForDev.java
+++ b/src/main/java/org/example/youth_be/user/service/response/GenerateTokensForDev.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class TokenReissueResponse {
+public class GenerateTokensForDev {
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/org/example/youth_be/user/service/response/TokenReissueResponse.java
+++ b/src/main/java/org/example/youth_be/user/service/response/TokenReissueResponse.java
@@ -1,0 +1,11 @@
+package org.example.youth_be.user.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenReissueResponse {
+    private String accessToken;
+    private String refreshToken;
+}


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
ex) feature (#8)
[티켓](https://songminhyuk0308.atlassian.net/jira/software/projects/CHUNGCHUN/boards/2?issueParent=10088&selectedIssue=CHUNGCHUN-127&sprints=5%2C6)

### 📌 작업사항
- 토큰 재발급 API를 작성하였습니다. 만료된 액세스 + 유효한 리프레시를 받아 새로운 액세스 토큰을 바디에 담아 내려주도록 합니다.
- 시큐리티 설정에서 화이트리스트 방식으로 구현하도록 변경했습니다.
- 로그인 시 가입된 회원이 없으면 새로 만들어 넣도록 수정했습니다.

### 🔥 리뷰어가 참고할 사항
