### PR TITLE
[CHUNGCHUN-141] 댓글 생성, 삭제, 목록 조회 api

### DIFF
--- a/src/main/java/org/example/youth_be/artwork/domain/ArtworkEntity.java
+++ b/src/main/java/org/example/youth_be/artwork/domain/ArtworkEntity.java
@@ -73,4 +73,12 @@ public class ArtworkEntity extends BaseEntity {
         this.imageIdList = imageIdList;
         this.thumbnailImageUrl = thumbnailImageUrl;
     }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        this.commentCount--;
+    }
 }

--- a/src/main/java/org/example/youth_be/comment/controller/CommentController.java
+++ b/src/main/java/org/example/youth_be/comment/controller/CommentController.java
@@ -24,8 +24,8 @@ public class CommentController implements CommentSpec {
     }
     @Override
     @PostMapping("/{artworkId}/comments")
-    public Long createArtworkComment(@CurrentUser TokenClaim claim, @PathVariable Long artworkId, CreateArtworkCommentRequest request) {
-        return commentService.createArtworkComment(claim, artworkId, request);
+    public void createArtworkComment(@CurrentUser TokenClaim claim, @PathVariable Long artworkId, CreateArtworkCommentRequest request) {
+        commentService.createArtworkComment(claim, artworkId, request);
     }
 
     @Override

--- a/src/main/java/org/example/youth_be/comment/controller/CommentController.java
+++ b/src/main/java/org/example/youth_be/comment/controller/CommentController.java
@@ -1,0 +1,36 @@
+package org.example.youth_be.comment.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.youth_be.comment.controller.spec.CommentSpec;
+import org.example.youth_be.comment.service.CommentService;
+import org.example.youth_be.comment.service.request.CreateArtworkCommentRequest;
+import org.example.youth_be.comment.service.response.CommentResponse;
+import org.example.youth_be.common.CurrentUser;
+import org.example.youth_be.common.PageParam;
+import org.example.youth_be.common.PageResponse;
+import org.example.youth_be.common.jwt.TokenClaim;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/artworks")
+public class CommentController implements CommentSpec {
+    private final CommentService commentService;
+
+    @Override
+    @GetMapping("/{artworkId}/comments")
+    public PageResponse<CommentResponse> getAllArtworkComments(@PathVariable Long artworkId, @ModelAttribute PageParam pageParam) {
+        return commentService.getArtworkComments(artworkId, pageParam);
+    }
+    @Override
+    @PostMapping("/{artworkId}/comments")
+    public Long createArtworkComment(@CurrentUser TokenClaim claim, @PathVariable Long artworkId, CreateArtworkCommentRequest request) {
+        return commentService.createArtworkComment(claim, artworkId, request);
+    }
+
+    @Override
+    @DeleteMapping("/{artworkId}/comments/{commentId}")
+    public void deleteArtworkComment(@CurrentUser TokenClaim claim, @PathVariable Long artworkId, @PathVariable Long commentId) {
+        commentService.deleteArtworkComment(claim, artworkId, commentId);
+    }
+}

--- a/src/main/java/org/example/youth_be/comment/controller/spec/CommentSpec.java
+++ b/src/main/java/org/example/youth_be/comment/controller/spec/CommentSpec.java
@@ -1,0 +1,20 @@
+package org.example.youth_be.comment.controller.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.youth_be.comment.service.request.CreateArtworkCommentRequest;
+import org.example.youth_be.comment.service.response.CommentResponse;
+import org.example.youth_be.common.ApiTags;
+import org.example.youth_be.common.PageParam;
+import org.example.youth_be.common.PageResponse;
+import org.example.youth_be.common.jwt.TokenClaim;
+
+@Tag(name = ApiTags.USER)
+public interface CommentSpec {
+    @Operation(description = "작품 댓글 조회 API")
+    PageResponse<CommentResponse> getAllArtworkComments(Long artworkId, PageParam pageParam);
+    @Operation(description = "작품 댓글 작성 API")
+    Long createArtworkComment(TokenClaim claim, Long artworkId, CreateArtworkCommentRequest request);
+    @Operation(description = "작품 댓글 삭제 API")
+    void deleteArtworkComment(TokenClaim claim, Long artworkId, Long commentId);
+}

--- a/src/main/java/org/example/youth_be/comment/controller/spec/CommentSpec.java
+++ b/src/main/java/org/example/youth_be/comment/controller/spec/CommentSpec.java
@@ -14,7 +14,7 @@ public interface CommentSpec {
     @Operation(description = "작품 댓글 조회 API")
     PageResponse<CommentResponse> getAllArtworkComments(Long artworkId, PageParam pageParam);
     @Operation(description = "작품 댓글 작성 API")
-    Long createArtworkComment(TokenClaim claim, Long artworkId, CreateArtworkCommentRequest request);
+    void createArtworkComment(TokenClaim claim, Long artworkId, CreateArtworkCommentRequest request);
     @Operation(description = "작품 댓글 삭제 API")
     void deleteArtworkComment(TokenClaim claim, Long artworkId, Long commentId);
 }

--- a/src/main/java/org/example/youth_be/comment/domain/CommentEntity.java
+++ b/src/main/java/org/example/youth_be/comment/domain/CommentEntity.java
@@ -17,8 +17,8 @@ public class CommentEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
-    @Column(nullable = false)
-    private String content;
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String contents;
 
     @Column(nullable = false)
     private Long userId;
@@ -27,10 +27,14 @@ public class CommentEntity extends BaseEntity {
     private Long artworkId;
 
     @Builder
-    public CommentEntity(Long commentId, String content, Long userId, Long artworkId) {
+    public CommentEntity(Long commentId, String contents, Long userId, Long artworkId) {
         this.commentId = commentId;
-        this.content = content;
+        this.contents = contents;
         this.userId = userId;
         this.artworkId = artworkId;
+    }
+
+    public boolean isOwner(Long userId) {
+        return this.userId.equals(userId);
     }
 }

--- a/src/main/java/org/example/youth_be/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/org/example/youth_be/comment/repository/CommentCustomRepository.java
@@ -1,0 +1,8 @@
+package org.example.youth_be.comment.repository;
+
+import org.example.youth_be.comment.repository.dto.ArtworkCommentQueryDto;
+import org.springframework.data.domain.Slice;
+
+public interface CommentCustomRepository {
+    Slice<ArtworkCommentQueryDto> findAllArtworkComments(Long artworkId, Long lastIdxId, Integer size);
+}

--- a/src/main/java/org/example/youth_be/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/org/example/youth_be/comment/repository/CommentCustomRepositoryImpl.java
@@ -1,0 +1,46 @@
+package org.example.youth_be.comment.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.youth_be.comment.repository.dto.ArtworkCommentQueryDto;
+import org.example.youth_be.comment.repository.dto.QArtworkCommentQueryDto;
+import org.example.youth_be.common.CursorPagingCommon;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+import static org.example.youth_be.comment.domain.QCommentEntity.commentEntity;
+import static org.example.youth_be.user.domain.QUserEntity.userEntity;
+
+@RequiredArgsConstructor
+public class CommentCustomRepositoryImpl implements CommentCustomRepository{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<ArtworkCommentQueryDto> findAllArtworkComments(Long artworkId, Long cursorId, Integer size) {
+        List<ArtworkCommentQueryDto> contents = jpaQueryFactory.select(new QArtworkCommentQueryDto(
+                                userEntity.profileImageUrl,
+                                userEntity.nickname,
+                                commentEntity.createdAt,
+                                commentEntity.contents
+                        )
+                )
+                .from(commentEntity)
+                .join(userEntity).on(userEntity.userId.eq(commentEntity.userId))
+                .where(
+                        ltLastIdxId(cursorId),
+                        commentEntity.artworkId.eq(artworkId)
+                )
+                .orderBy(commentEntity.commentId.desc())
+                .fetch();
+        return CursorPagingCommon.getSlice(contents, size);
+    }
+
+    private BooleanExpression ltLastIdxId(Long cursorId) {
+        if (cursorId == null) {
+            return null;
+        }
+        return commentEntity.commentId.lt(cursorId);
+    }
+}

--- a/src/main/java/org/example/youth_be/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/org/example/youth_be/comment/repository/CommentCustomRepositoryImpl.java
@@ -14,12 +14,13 @@ import static org.example.youth_be.comment.domain.QCommentEntity.commentEntity;
 import static org.example.youth_be.user.domain.QUserEntity.userEntity;
 
 @RequiredArgsConstructor
-public class CommentCustomRepositoryImpl implements CommentCustomRepository{
+public class CommentCustomRepositoryImpl implements CommentCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public Slice<ArtworkCommentQueryDto> findAllArtworkComments(Long artworkId, Long cursorId, Integer size) {
         List<ArtworkCommentQueryDto> contents = jpaQueryFactory.select(new QArtworkCommentQueryDto(
+                                commentEntity.commentId,
                                 userEntity.profileImageUrl,
                                 userEntity.nickname,
                                 commentEntity.createdAt,
@@ -33,7 +34,9 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository{
                         commentEntity.artworkId.eq(artworkId)
                 )
                 .orderBy(commentEntity.commentId.desc())
+                .limit(size + 1)
                 .fetch();
+
         return CursorPagingCommon.getSlice(contents, size);
     }
 

--- a/src/main/java/org/example/youth_be/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/youth_be/comment/repository/CommentRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+public interface CommentRepository extends JpaRepository<CommentEntity, Long>, CommentCustomRepository {
 }

--- a/src/main/java/org/example/youth_be/comment/repository/dto/ArtworkCommentQueryDto.java
+++ b/src/main/java/org/example/youth_be/comment/repository/dto/ArtworkCommentQueryDto.java
@@ -1,0 +1,22 @@
+package org.example.youth_be.comment.repository.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ArtworkCommentQueryDto {
+    private String profileImage;
+    private String nickname;
+    private LocalDateTime createdAt;
+    private String contents;
+
+    @QueryProjection
+    public ArtworkCommentQueryDto(String profileImage, String nickname, LocalDateTime createdAt, String contents) {
+        this.profileImage = profileImage;
+        this.nickname = nickname;
+        this.createdAt = createdAt;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/org/example/youth_be/comment/repository/dto/ArtworkCommentQueryDto.java
+++ b/src/main/java/org/example/youth_be/comment/repository/dto/ArtworkCommentQueryDto.java
@@ -7,13 +7,15 @@ import java.time.LocalDateTime;
 
 @Getter
 public class ArtworkCommentQueryDto {
+    private Long commentId;
     private String profileImage;
     private String nickname;
     private LocalDateTime createdAt;
     private String contents;
 
     @QueryProjection
-    public ArtworkCommentQueryDto(String profileImage, String nickname, LocalDateTime createdAt, String contents) {
+    public ArtworkCommentQueryDto(Long commentId, String profileImage, String nickname, LocalDateTime createdAt, String contents) {
+        this.commentId = commentId;
         this.profileImage = profileImage;
         this.nickname = nickname;
         this.createdAt = createdAt;

--- a/src/main/java/org/example/youth_be/comment/service/CommentService.java
+++ b/src/main/java/org/example/youth_be/comment/service/CommentService.java
@@ -1,0 +1,69 @@
+package org.example.youth_be.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.youth_be.artwork.domain.ArtworkEntity;
+import org.example.youth_be.artwork.repository.ArtworkRepository;
+import org.example.youth_be.comment.domain.CommentEntity;
+import org.example.youth_be.comment.repository.CommentRepository;
+import org.example.youth_be.comment.repository.dto.ArtworkCommentQueryDto;
+import org.example.youth_be.comment.service.request.CreateArtworkCommentRequest;
+import org.example.youth_be.comment.service.response.CommentResponse;
+import org.example.youth_be.common.PageParam;
+import org.example.youth_be.common.PageResponse;
+import org.example.youth_be.common.exceptions.YouthBadRequestException;
+import org.example.youth_be.common.exceptions.YouthNotFoundException;
+import org.example.youth_be.common.jwt.TokenClaim;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final ArtworkRepository artworkRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public PageResponse<CommentResponse> getArtworkComments(Long artworkId, PageParam pageParam) {
+        Slice<ArtworkCommentQueryDto> allArtworkComments = commentRepository.findAllArtworkComments(artworkId, pageParam.getLastIdxId(), pageParam.getSize());
+        return PageResponse.of(allArtworkComments.getContent().stream().map(CommentResponse::of).collect(Collectors.toList()),
+                allArtworkComments.hasNext());
+    }
+
+    @Transactional
+    public Long createArtworkComment(TokenClaim claim, Long artworkId, CreateArtworkCommentRequest request) {
+        ArtworkEntity artworkEntity = artworkRepository.findById(artworkId).orElseThrow(() -> new YouthNotFoundException("작품을 찾을 수 없습니다.", null));
+        CommentEntity newCommentEntity = CommentEntity.builder()
+                .contents(request.getContents())
+                .artworkId(artworkId)
+                .userId(claim.getUserId())
+                .build();
+        Long commentId = commentRepository.save(newCommentEntity).getCommentId();
+        artworkEntity.increaseCommentCount();
+        logger.info("create comment ok - userId: {}, artworkId: {}, commentId: {}", claim.getUserId(), artworkId, commentId);
+        return commentId;
+    }
+
+    @Transactional
+    public void deleteArtworkComment(TokenClaim claim, Long artworkId, Long commentId) {
+        ArtworkEntity artworkEntity = artworkRepository.findById(artworkId).orElseThrow(() -> new YouthNotFoundException("작품을 찾을 수 없습니다.", null));
+        CommentEntity commentEntity = commentRepository.findById(commentId).orElseThrow(() -> new YouthNotFoundException("댓글을 찾을 수 없습니다.", null));
+
+        validateCommentOwner(commentEntity, claim.getUserId());
+        commentRepository.delete(commentEntity);
+        artworkEntity.decreaseCommentCount();
+        logger.info("delete comment ok - userId: {}, artworkId: {}, commentId: {}", claim.getUserId(), artworkId, commentId);
+    }
+
+    private void validateCommentOwner(CommentEntity commentEntity, Long userId) {
+        if (commentEntity.isOwner(userId)) {
+            return;
+        }
+        throw new YouthBadRequestException("댓글 삭제는 작성자만 가능합니다.", null);
+    }
+}

--- a/src/main/java/org/example/youth_be/comment/service/CommentService.java
+++ b/src/main/java/org/example/youth_be/comment/service/CommentService.java
@@ -51,10 +51,10 @@ public class CommentService {
 
     @Transactional
     public void deleteArtworkComment(TokenClaim claim, Long artworkId, Long commentId) {
-        ArtworkEntity artworkEntity = artworkRepository.findById(artworkId).orElseThrow(() -> new YouthNotFoundException("작품을 찾을 수 없습니다.", null));
         CommentEntity commentEntity = commentRepository.findById(commentId).orElseThrow(() -> new YouthNotFoundException("댓글을 찾을 수 없습니다.", null));
-
         validateCommentOwner(commentEntity, claim.getUserId());
+
+        ArtworkEntity artworkEntity = artworkRepository.findById(artworkId).orElseThrow(() -> new YouthNotFoundException("작품을 찾을 수 없습니다.", null));
         commentRepository.delete(commentEntity);
         artworkEntity.decreaseCommentCount();
         logger.info("delete comment ok - userId: {}, artworkId: {}, commentId: {}", claim.getUserId(), artworkId, commentId);

--- a/src/main/java/org/example/youth_be/comment/service/request/CreateArtworkCommentRequest.java
+++ b/src/main/java/org/example/youth_be/comment/service/request/CreateArtworkCommentRequest.java
@@ -1,0 +1,12 @@
+package org.example.youth_be.comment.service.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateArtworkCommentRequest {
+    @Schema(description = "댓글 내용, 글자 제한 없음")
+    private String contents;
+}

--- a/src/main/java/org/example/youth_be/comment/service/response/CommentResponse.java
+++ b/src/main/java/org/example/youth_be/comment/service/response/CommentResponse.java
@@ -1,0 +1,34 @@
+package org.example.youth_be.comment.service.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.youth_be.comment.repository.dto.ArtworkCommentQueryDto;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+@AllArgsConstructor
+public class CommentResponse {
+    @Schema(description = "프로필 이미지 url")
+    private String profileUrl;
+    @Schema(description = "닉네임")
+    private String nickname;
+    @Schema(description = "작성일자")
+    private LocalDateTime createdAt;
+    @Schema(description = "댓글 내용")
+    private String contents;
+
+    public static CommentResponse of (ArtworkCommentQueryDto queryDto) {
+        return new CommentResponse(
+                queryDto.getProfileImage(),
+                queryDto.getNickname(),
+                queryDto.getCreatedAt(),
+                queryDto.getContents()
+        );
+    }
+}

--- a/src/main/java/org/example/youth_be/comment/service/response/CommentResponse.java
+++ b/src/main/java/org/example/youth_be/comment/service/response/CommentResponse.java
@@ -14,6 +14,8 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 public class CommentResponse {
+    @Schema(description = "댓글 ID")
+    private Long commentId;
     @Schema(description = "프로필 이미지 url")
     private String profileUrl;
     @Schema(description = "닉네임")
@@ -25,6 +27,7 @@ public class CommentResponse {
 
     public static CommentResponse of (ArtworkCommentQueryDto queryDto) {
         return new CommentResponse(
+                queryDto.getCommentId(),
                 queryDto.getProfileImage(),
                 queryDto.getNickname(),
                 queryDto.getCreatedAt(),

--- a/src/main/java/org/example/youth_be/common/ApiTags.java
+++ b/src/main/java/org/example/youth_be/common/ApiTags.java
@@ -6,4 +6,5 @@ public class ApiTags {
     public static final String IMAGE = "이미지 업로드 API";
 
     public static final String ARTWORK = "작품 API";
+    public static final String COMMENT = "댓글 API";
 }

--- a/src/main/java/org/example/youth_be/common/PageParam.java
+++ b/src/main/java/org/example/youth_be/common/PageParam.java
@@ -1,0 +1,11 @@
+package org.example.youth_be.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PageParam {
+    private Long lastIdxId;
+    private Integer size;
+}

--- a/src/main/java/org/example/youth_be/common/PageResponse.java
+++ b/src/main/java/org/example/youth_be/common/PageResponse.java
@@ -15,4 +15,8 @@ public class PageResponse<T> {
     public static <T> PageResponse<T> of(Slice<T> slice) {
         return new PageResponse<>(slice.getContent(), slice.hasNext());
     }
+
+    public static <T> PageResponse<T> of(List<T> contents, boolean hasNext) {
+        return new PageResponse<>(contents, hasNext);
+    }
 }

--- a/src/main/java/org/example/youth_be/common/security/SecurityConfig.java
+++ b/src/main/java/org/example/youth_be/common/security/SecurityConfig.java
@@ -80,8 +80,12 @@ public class SecurityConfig {
                         .requestMatchers(
                                 antMatcher(HttpMethod.POST, "/image/profile"),
                                 antMatcher(HttpMethod.DELETE, "/image/profile"))
-                                .hasAnyRole(UserRoleEnum.REGULAR.name(), UserRoleEnum.ASSOCIATE.name()
-                        )
+                                .hasAnyRole(UserRoleEnum.REGULAR.name(), UserRoleEnum.ASSOCIATE.name())
+                        .requestMatchers(
+                                antMatcher(HttpMethod.POST, "/artworks/{artworksId}/comments"),
+                                antMatcher(HttpMethod.DELETE, "/artworks/{artworksId}/comments/{commentId}"))
+                                .hasRole(UserRoleEnum.REGULAR.name())
+                        .requestMatchers(antMatcher(HttpMethod.GET, "/artworks/{artworksId}/comments")).permitAll()
                         .requestMatchers(antMatcher(HttpMethod.GET, "/artworks")).permitAll()
                         .requestMatchers(antMatcher(HttpMethod.GET, "/users/{userId}")).permitAll()
                         .requestMatchers(antMatcher(HttpMethod.GET, "/users/{userId}/artworks")).permitAll()


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
[티켓](https://songminhyuk0308.atlassian.net/jira/software/projects/CHUNGCHUN/boards/2?selectedIssue=CHUNGCHUN-141)

### 📌 작업사항
- 댓글의 생성, 삭제, 목록 조회 api를 작성했습니다.
- PageParam 클래스를 추가했는데, 기존의 artwork prefix를 가진 페이지 파라미터 클래스는 작품에 종속적인 네이밍이라 판단했기 때문입니다.

### 🔥 리뷰어가 참고할 사항
