### PR TITLE
[FIX] 작품 상세 조회 시 좋아요 여부 응답 추가(LikeId), 좋아요 등록, 삭제시 totalLikeCount 증,감소 수정

### DIFF
--- a/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
+++ b/src/main/java/org/example/youth_be/artwork/controller/ArtworkController.java
@@ -44,8 +44,8 @@ public class ArtworkController implements ArtworkSpec {
 
     @GetMapping("/{artworkId}")
     @ResponseStatus(HttpStatus.OK)
-    public ArtworkDetailResponse getArtwork(@PathVariable Long artworkId) {
-        return artworkService.getArtwork(artworkId);
+    public ArtworkDetailResponse getArtwork(@PathVariable Long artworkId, @CurrentUser TokenClaim tokenClaim) {
+        return artworkService.getArtwork(tokenClaim, artworkId);
     }
 
     @PutMapping("/{artworkId}")

--- a/src/main/java/org/example/youth_be/artwork/controller/spec/ArtworkSpec.java
+++ b/src/main/java/org/example/youth_be/artwork/controller/spec/ArtworkSpec.java
@@ -29,7 +29,7 @@ public interface ArtworkSpec {
 
 
     @Operation(description = "작품 상세 조회 API입니다.")
-    ArtworkDetailResponse getArtwork(Long artworkId);
+    ArtworkDetailResponse getArtwork(Long artworkId, TokenClaim tokenClaim);
 
     @Operation(description = "작품 수정 API입니다.")
     void updateArtwork(TokenClaim tokenClaim, Long artworkId, ArtworkUpdateRequest request);

--- a/src/main/java/org/example/youth_be/artwork/service/ArtworkService.java
+++ b/src/main/java/org/example/youth_be/artwork/service/ArtworkService.java
@@ -17,6 +17,7 @@ import org.example.youth_be.common.exceptions.YouthNotFoundException;
 import org.example.youth_be.common.jwt.TokenClaim;
 import org.example.youth_be.image.domain.ImageEntity;
 import org.example.youth_be.image.repository.ImageRepository;
+import org.example.youth_be.like.domain.LikeEntity;
 import org.example.youth_be.like.repository.LikeRepository;
 import org.example.youth_be.s3.service.FileUploader;
 import org.example.youth_be.user.domain.UserEntity;
@@ -104,7 +105,10 @@ public class ArtworkService {
 
         Long likeId = null;
         if (userId != null) {
-            likeId = likeRepository.findByArtworkIdAndUserId(artworkId, userEntity.getUserId()).orElse(null);
+            LikeEntity likeEntity = likeRepository.findByArtworkIdAndUserId(artworkId, userId).orElse(null);
+            if (likeEntity != null) {
+                likeId = likeEntity.getLikeId();
+            }
         }
 
         List<Long> ids = artworkEntity.getImageIdList();

--- a/src/main/java/org/example/youth_be/artwork/service/ArtworkService.java
+++ b/src/main/java/org/example/youth_be/artwork/service/ArtworkService.java
@@ -98,18 +98,7 @@ public class ArtworkService {
         // 작가 entity 조회
         UserEntity userEntity = userRepository.findById(artworkEntity.getUserId()).orElseThrow(() -> new YouthNotFoundException("해당 ID의 유저를 찾을 수 없습니다.", null));
 
-        // tokenClaim이 없을 경우 null 반환
-        Long userId = Optional.ofNullable(tokenClaim)
-                .map(TokenClaim::getUserId)
-                .orElse(null);
-
-        Long likeId = null;
-        if (userId != null) {
-            LikeEntity likeEntity = likeRepository.findByArtworkIdAndUserId(artworkId, userId).orElse(null);
-            if (likeEntity != null) {
-                likeId = likeEntity.getLikeId();
-            }
-        }
+        Long likeId = getLikeId(tokenClaim, artworkId);
 
         List<Long> ids = artworkEntity.getImageIdList();
         List<ImageEntity> images = imageRepository.findAllById(ids);
@@ -125,6 +114,22 @@ public class ArtworkService {
                 .collect(Collectors.toList());
 
         return ArtworkDetailResponse.of(userEntity, artworkEntity, artworkImageResponses, likeId);
+    }
+
+    private Long getLikeId(TokenClaim tokenClaim, Long artworkId) {
+        // tokenClaim이 없을 경우 null 반환
+        Long userId = Optional.ofNullable(tokenClaim)
+                .map(TokenClaim::getUserId)
+                .orElse(null);
+
+        Long likeId = null;
+        if (userId != null) {
+            LikeEntity likeEntity = likeRepository.findByArtworkIdAndUserId(artworkId, userId).orElse(null);
+            if (likeEntity != null) {
+                likeId = likeEntity.getLikeId();
+            }
+        }
+        return likeId;
     }
 
     @Transactional

--- a/src/main/java/org/example/youth_be/artwork/service/response/ArtworkDetailResponse.java
+++ b/src/main/java/org/example/youth_be/artwork/service/response/ArtworkDetailResponse.java
@@ -26,8 +26,9 @@ public class ArtworkDetailResponse {
     private String artistProfileImageUrl;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private Long likeId;
 
-    public static ArtworkDetailResponse of(UserEntity userEntity, ArtworkEntity artworkEntity, List<ArtworkImageResponse> artworkImageResponse) {
+    public static ArtworkDetailResponse of(UserEntity userEntity, ArtworkEntity artworkEntity, List<ArtworkImageResponse> artworkImageResponse, Long likeId) {
         return ArtworkDetailResponse.builder()
                 .artworkId(artworkEntity.getArtworkId())
                 .title(artworkEntity.getTitle())
@@ -43,6 +44,7 @@ public class ArtworkDetailResponse {
                 .artistProfileImageUrl(userEntity.getProfileImageUrl())
                 .createdAt(artworkEntity.getCreatedAt())
                 .updatedAt(artworkEntity.getUpdatedAt())
+                .likeId(likeId)
                 .build();
     }
 }

--- a/src/main/java/org/example/youth_be/common/ApiTags.java
+++ b/src/main/java/org/example/youth_be/common/ApiTags.java
@@ -7,4 +7,5 @@ public class ApiTags {
 
     public static final String ARTWORK = "작품 API";
     public static final String COMMENT = "댓글 API";
+    public static final String LIKE = "좋아요 API";
 }

--- a/src/main/java/org/example/youth_be/like/controller/spec/LikeSpec.java
+++ b/src/main/java/org/example/youth_be/like/controller/spec/LikeSpec.java
@@ -1,8 +1,11 @@
 package org.example.youth_be.like.controller.spec;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.youth_be.common.ApiTags;
 import org.example.youth_be.common.jwt.TokenClaim;
 
+@Tag(name = ApiTags.LIKE)
 public interface LikeSpec {
 
     @Operation(description = "작품 좋아요 생성 API입니다.")

--- a/src/main/java/org/example/youth_be/like/repository/LikeRepository.java
+++ b/src/main/java/org/example/youth_be/like/repository/LikeRepository.java
@@ -4,6 +4,10 @@ import org.example.youth_be.like.domain.LikeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
+
+    Optional<Long> findByArtworkIdAndUserId(Long artworkId, Long userId);
 }

--- a/src/main/java/org/example/youth_be/like/repository/LikeRepository.java
+++ b/src/main/java/org/example/youth_be/like/repository/LikeRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 @Repository
 public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
 
-    Optional<Long> findByArtworkIdAndUserId(Long artworkId, Long userId);
+    Optional<LikeEntity> findByArtworkIdAndUserId(Long artworkId, Long userId);
 }

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -84,4 +84,12 @@ public class UserEntity extends BaseEntity {
     public void deleteUserProfileImageUrl(){
         this.profileImageUrl = null;
     }
+
+    public void increaseTotalLikeCount() {
+        this.totalLikeCount++;
+    }
+
+    public void decreaseTotalLikeCount() {
+        this.totalLikeCount--;
+    }
 }

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -60,8 +60,8 @@ public class UserEntity extends BaseEntity {
         this.activityArea = activityArea;
         this.description = description;
         this.userRole = userRole;
-        this.totalLikeCount = totalLikeCount;
-        this.followerCount = followerCount;
+        this.totalLikeCount = 0L;
+        this.followerCount = 0L;
     }
 
     public void updateProfile(String profileImageUrl, String nickname, String activityField, String activityArea, String description) {

--- a/src/main/java/org/example/youth_be/user/domain/UserEntity.java
+++ b/src/main/java/org/example/youth_be/user/domain/UserEntity.java
@@ -91,6 +91,7 @@ public class UserEntity extends BaseEntity {
 
     public void decreaseTotalLikeCount() {
         this.totalLikeCount--;
+    }
 
     public void increaseFollowCount() {
         this.followerCount++;


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
fix

### 📌 작업사항
- 기존에 작품 상세 조회시에 좋아요 여부에 대한 응답을 추가했습니다.
- 기존에 좋아요 등록 및 취소 api에서 작가의 totalLikeCount 증,감소 로직을 추가했습니다.

### 🔥 리뷰어가 참고할 사항
