### PR TITLE
[FIX] 링크 응답 시 address를 url로 변경

### DIFF
--- a/src/main/java/org/example/youth_be/user/service/response/LinkResponse.java
+++ b/src/main/java/org/example/youth_be/user/service/response/LinkResponse.java
@@ -9,7 +9,7 @@ import org.example.youth_be.user.domain.UserLinkEntity;
 public class LinkResponse {
     private Long linkId;
     private String title;
-    private String address;
+    private String url;
 
     static public LinkResponse of(UserLinkEntity userLinkEntity) {
         return new LinkResponse(


### PR DESCRIPTION
### ✅ PR 타입 & 티켓번호
ex) feature (#8)

### 📌 작업사항
- 링크 조회 응답 프로퍼티 이름을 address에서 url로 변경합니다.

### 🔥 리뷰어가 참고할 사항
